### PR TITLE
Feat/auth service

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -11,23 +11,27 @@
         "@emotion/react": "^11.13.3",
         "@emotion/style": "^0.8.0",
         "@emotion/styled": "^11.13.0",
+        "axios": "^1.7.7",
         "emotion": "^11.0.0",
+        "formik": "^2.4.6",
         "react": "^18.3.1",
         "react-dom": "^18.3.1",
-        "react-router-dom": "^6.26.1"
+        "react-icons": "^5.3.0",
+        "react-router-dom": "^6.26.1",
+        "zustand": "^4.5.5"
       },
       "devDependencies": {
-        "@eslint/js": "^9.9.1",
-        "@types/react": "^18.3.5",
+        "@eslint/js": "^9.10.0",
+        "@types/react": "^18.3.6",
         "@types/react-dom": "^18.3.0",
         "@vitejs/plugin-react": "^4.3.1",
-        "eslint": "^9.9.1",
+        "eslint": "^9.10.0",
         "eslint-plugin-react-hooks": "5.1.0-rc-fb9a90fa48-20240614",
-        "eslint-plugin-react-refresh": "^0.4.11",
+        "eslint-plugin-react-refresh": "^0.4.12",
         "globals": "^15.9.0",
-        "typescript": "^5.5.4",
-        "typescript-eslint": "^8.3.0",
-        "vite": "^5.4.2"
+        "typescript": "^5.6.2",
+        "typescript-eslint": "^8.5.0",
+        "vite": "^5.4.5"
       }
     },
     "node_modules/@ampproject/remapping": {
@@ -1476,6 +1480,15 @@
       "integrity": "sha512-/kYRxGDLWzHOB7q+wtSUQlFrtcdUccpfy+X+9iMBpHK8QLLhx2wIPYuS5DYtR9Wa/YlZAbIovy7qVdB1Aq6Lyw==",
       "dev": true
     },
+    "node_modules/@types/hoist-non-react-statics": {
+      "version": "3.3.5",
+      "resolved": "https://registry.npmjs.org/@types/hoist-non-react-statics/-/hoist-non-react-statics-3.3.5.tgz",
+      "integrity": "sha512-SbcrWzkKBw2cdwRTwQAswfpB9g9LJWfjtUeW/jvNwbhC8cpmmNYVePa+ncbUe0rGTQ7G3Ff6mYUN2VMfLVr+Sg==",
+      "dependencies": {
+        "@types/react": "*",
+        "hoist-non-react-statics": "^3.3.0"
+      }
+    },
     "node_modules/@types/parse-json": {
       "version": "4.0.2",
       "resolved": "https://registry.npmjs.org/@types/parse-json/-/parse-json-4.0.2.tgz",
@@ -1484,14 +1497,12 @@
     "node_modules/@types/prop-types": {
       "version": "15.7.12",
       "resolved": "https://registry.npmjs.org/@types/prop-types/-/prop-types-15.7.12.tgz",
-      "integrity": "sha512-5zvhXYtRNRluoE/jAp4GVsSduVUzNWKkOZrCDBWYtE7biZywwdC2AcEzg+cSMLFRfVgeAFqpfNabiPjxFddV1Q==",
-      "dev": true
+      "integrity": "sha512-5zvhXYtRNRluoE/jAp4GVsSduVUzNWKkOZrCDBWYtE7biZywwdC2AcEzg+cSMLFRfVgeAFqpfNabiPjxFddV1Q=="
     },
     "node_modules/@types/react": {
-      "version": "18.3.5",
-      "resolved": "https://registry.npmjs.org/@types/react/-/react-18.3.5.tgz",
-      "integrity": "sha512-WeqMfGJLGuLCqHGYRGHxnKrXcTitc6L/nBUWfWPcTarG3t9PsquqUMuVeXZeca+mglY4Vo5GZjCi0A3Or2lnxA==",
-      "dev": true,
+      "version": "18.3.7",
+      "resolved": "https://registry.npmjs.org/@types/react/-/react-18.3.7.tgz",
+      "integrity": "sha512-KUnDCJF5+AiZd8owLIeVHqmW9yM4sqmDVf2JRJiBMFkGvkoZ4/WyV2lL4zVsoinmRS/W3FeEdZLEWFRofnT2FQ==",
       "dependencies": {
         "@types/prop-types": "*",
         "csstype": "^3.0.2"
@@ -1818,6 +1829,21 @@
       "integrity": "sha512-8+9WqebbFzpX9OR+Wa6O29asIogeRMzcGtAINdpMHHyAg10f05aSFVBbcEqGf/PXw1EjAZ+q2/bEBg3DvurK3Q==",
       "dev": true
     },
+    "node_modules/asynckit": {
+      "version": "0.4.0",
+      "resolved": "https://registry.npmjs.org/asynckit/-/asynckit-0.4.0.tgz",
+      "integrity": "sha512-Oei9OH4tRh0YqU3GxhX79dM/mwVgvbZJaSNaRk+bshkj0S5cfHcgYakreBjrHwatXKbz+IoIdYLxrKim2MjW0Q=="
+    },
+    "node_modules/axios": {
+      "version": "1.7.7",
+      "resolved": "https://registry.npmjs.org/axios/-/axios-1.7.7.tgz",
+      "integrity": "sha512-S4kL7XrjgBmvdGut0sN3yJxqYzrDOnivkBiN0OFs6hLiUam3UPvswUo0kqGyhqUZGEOytHyumEdXsAkgCOUf3Q==",
+      "dependencies": {
+        "follow-redirects": "^1.15.6",
+        "form-data": "^4.0.0",
+        "proxy-from-env": "^1.1.0"
+      }
+    },
     "node_modules/babel-plugin-macros": {
       "version": "3.1.0",
       "resolved": "https://registry.npmjs.org/babel-plugin-macros/-/babel-plugin-macros-3.1.0.tgz",
@@ -1954,6 +1980,17 @@
       "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.3.tgz",
       "integrity": "sha512-72fSenhMw2HZMTVHeCA9KCmpEIbzWiQsjN+BHcBbS9vr1mtt+vJjPdksIBNUmKAW8TFUDPJK5SUU3QhE9NEXDw=="
     },
+    "node_modules/combined-stream": {
+      "version": "1.0.8",
+      "resolved": "https://registry.npmjs.org/combined-stream/-/combined-stream-1.0.8.tgz",
+      "integrity": "sha512-FQN4MRfuJeHf7cBbBMJFXhKSDq+2kAArBlmRBvcvFE5BB1HZKXtSFASDhdlz9zOYwxh8lDdnvmMOe/+5cdoEdg==",
+      "dependencies": {
+        "delayed-stream": "~1.0.0"
+      },
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
     "node_modules/concat-map": {
       "version": "0.0.1",
       "resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz",
@@ -2020,6 +2057,22 @@
       "resolved": "https://registry.npmjs.org/deep-is/-/deep-is-0.1.4.tgz",
       "integrity": "sha512-oIPzksmTg4/MriiaYGO+okXDT7ztn/w3Eptv/+gSIdMdKsJo0u4CfYNFJPy+4SKMuCqGw2wxnA+URMg3t8a/bQ==",
       "dev": true
+    },
+    "node_modules/deepmerge": {
+      "version": "2.2.1",
+      "resolved": "https://registry.npmjs.org/deepmerge/-/deepmerge-2.2.1.tgz",
+      "integrity": "sha512-R9hc1Xa/NOBi9WRVUWg19rl1UB7Tt4kuPd+thNJgFZoxXsTz7ncaPaeIm+40oSGuP33DfMb4sZt1QIGiJzC4EA==",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/delayed-stream": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/delayed-stream/-/delayed-stream-1.0.0.tgz",
+      "integrity": "sha512-ZySD7Nf91aLB0RxL4KGrKHBXl7Eds1DAmEdcoVawXnLD7SDhpNgtuII2aAkg7a7QS41jxPSZ17p4VdGnMHk3MQ==",
+      "engines": {
+        "node": ">=0.4.0"
+      }
     },
     "node_modules/electron-to-chromium": {
       "version": "1.5.18",
@@ -2170,9 +2223,9 @@
       }
     },
     "node_modules/eslint-plugin-react-refresh": {
-      "version": "0.4.11",
-      "resolved": "https://registry.npmjs.org/eslint-plugin-react-refresh/-/eslint-plugin-react-refresh-0.4.11.tgz",
-      "integrity": "sha512-wrAKxMbVr8qhXTtIKfXqAn5SAtRZt0aXxe5P23Fh4pUAdC6XEsybGLB8P0PI4j1yYqOgUEUlzKAGDfo7rJOjcw==",
+      "version": "0.4.12",
+      "resolved": "https://registry.npmjs.org/eslint-plugin-react-refresh/-/eslint-plugin-react-refresh-0.4.12.tgz",
+      "integrity": "sha512-9neVjoGv20FwYtCP6CB1dzR1vr57ZDNOXst21wd2xJ/cTlM2xLq0GWVlSNTdMn/4BtP6cHYBMCSp1wFBJ9jBsg==",
       "dev": true,
       "peerDependencies": {
         "eslint": ">=7"
@@ -2453,6 +2506,62 @@
       "resolved": "https://registry.npmjs.org/flatted/-/flatted-3.3.1.tgz",
       "integrity": "sha512-X8cqMLLie7KsNUDSdzeN8FYK9rEt4Dt67OsG/DNGnYTSDBG4uFAJFBnUeiV+zCVAvwFy56IjM9sH51jVaEhNxw==",
       "dev": true
+    },
+    "node_modules/follow-redirects": {
+      "version": "1.15.9",
+      "resolved": "https://registry.npmjs.org/follow-redirects/-/follow-redirects-1.15.9.tgz",
+      "integrity": "sha512-gew4GsXizNgdoRyqmyfMHyAmXsZDk6mHkSxZFCzW9gwlbtOW44CDtYavM+y+72qD/Vq2l550kMF52DT8fOLJqQ==",
+      "funding": [
+        {
+          "type": "individual",
+          "url": "https://github.com/sponsors/RubenVerborgh"
+        }
+      ],
+      "engines": {
+        "node": ">=4.0"
+      },
+      "peerDependenciesMeta": {
+        "debug": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/form-data": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/form-data/-/form-data-4.0.0.tgz",
+      "integrity": "sha512-ETEklSGi5t0QMZuiXoA/Q6vcnxcLQP5vdugSpuAyi6SVGi2clPPp+xgEhuMaHC+zGgn31Kd235W35f7Hykkaww==",
+      "dependencies": {
+        "asynckit": "^0.4.0",
+        "combined-stream": "^1.0.8",
+        "mime-types": "^2.1.12"
+      },
+      "engines": {
+        "node": ">= 6"
+      }
+    },
+    "node_modules/formik": {
+      "version": "2.4.6",
+      "resolved": "https://registry.npmjs.org/formik/-/formik-2.4.6.tgz",
+      "integrity": "sha512-A+2EI7U7aG296q2TLGvNapDNTZp1khVt5Vk0Q/fyfSROss0V/V6+txt2aJnwEos44IxTCW/LYAi/zgWzlevj+g==",
+      "funding": [
+        {
+          "type": "individual",
+          "url": "https://opencollective.com/formik"
+        }
+      ],
+      "dependencies": {
+        "@types/hoist-non-react-statics": "^3.3.1",
+        "deepmerge": "^2.1.1",
+        "hoist-non-react-statics": "^3.3.0",
+        "lodash": "^4.17.21",
+        "lodash-es": "^4.17.21",
+        "react-fast-compare": "^2.0.1",
+        "tiny-warning": "^1.0.2",
+        "tslib": "^2.0.0"
+      },
+      "peerDependencies": {
+        "react": ">=16.8.0"
+      }
     },
     "node_modules/fsevents": {
       "version": "2.3.3",
@@ -2744,6 +2853,16 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
+    "node_modules/lodash": {
+      "version": "4.17.21",
+      "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.21.tgz",
+      "integrity": "sha512-v2kDEe57lecTulaDIuNTPy3Ry4gLGJ6Z1O3vE1krgXZNrsQ+LFTGHVxVjcXPs17LhbZVGedAJv8XZ1tvj5FvSg=="
+    },
+    "node_modules/lodash-es": {
+      "version": "4.17.21",
+      "resolved": "https://registry.npmjs.org/lodash-es/-/lodash-es-4.17.21.tgz",
+      "integrity": "sha512-mKnC+QJ9pWVzv+C4/U3rRsHapFfHvQFoFB92e52xeyGMcX6/OlIl78je1u8vePzYZSkkogMPJ2yjxxsb89cxyw=="
+    },
     "node_modules/lodash.merge": {
       "version": "4.6.2",
       "resolved": "https://registry.npmjs.org/lodash.merge/-/lodash.merge-4.6.2.tgz",
@@ -2790,6 +2909,25 @@
       },
       "engines": {
         "node": ">=8.6"
+      }
+    },
+    "node_modules/mime-db": {
+      "version": "1.52.0",
+      "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.52.0.tgz",
+      "integrity": "sha512-sPU4uV7dYlvtWJxwwxHD0PuihVNiE7TyAbQ5SWxDCB9mUYvOgroQOwYQQOKPJ8CIbE+1ETVlOoK1UC2nU3gYvg==",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/mime-types": {
+      "version": "2.1.35",
+      "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-2.1.35.tgz",
+      "integrity": "sha512-ZDY+bPm5zTTF+YpCrAU9nK0UgICYPT0QtT1NZWFv4s++TNkcgVaT0g6+4R2uI4MjQjzysHB1zxuWL50hzaeXiw==",
+      "dependencies": {
+        "mime-db": "1.52.0"
+      },
+      "engines": {
+        "node": ">= 0.6"
       }
     },
     "node_modules/minimatch": {
@@ -2999,6 +3137,11 @@
         "node": ">= 0.8.0"
       }
     },
+    "node_modules/proxy-from-env": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/proxy-from-env/-/proxy-from-env-1.1.0.tgz",
+      "integrity": "sha512-D+zkORCbA9f1tdWRK0RaCR3GPv50cMxcrz4X8k5LTSUD1Dkw47mKJEZQNunItRTkWwgtaUSo1RVFRIG9ZXiFYg=="
+    },
     "node_modules/punycode": {
       "version": "2.3.1",
       "resolved": "https://registry.npmjs.org/punycode/-/punycode-2.3.1.tgz",
@@ -3049,6 +3192,19 @@
       },
       "peerDependencies": {
         "react": "^18.3.1"
+      }
+    },
+    "node_modules/react-fast-compare": {
+      "version": "2.0.4",
+      "resolved": "https://registry.npmjs.org/react-fast-compare/-/react-fast-compare-2.0.4.tgz",
+      "integrity": "sha512-suNP+J1VU1MWFKcyt7RtjiSWUjvidmQSlqu+eHslq+342xCbGTYmC0mEhPCOHxlW0CywylOC1u2DFAT+bv4dBw=="
+    },
+    "node_modules/react-icons": {
+      "version": "5.3.0",
+      "resolved": "https://registry.npmjs.org/react-icons/-/react-icons-5.3.0.tgz",
+      "integrity": "sha512-DnUk8aFbTyQPSkCfF8dbX6kQjXA9DktMeJqfjrg6cK9vwQVMxmcA3BfP4QoiztVmEHtwlTgLFsPuH2NskKT6eg==",
+      "peerDependencies": {
+        "react": "*"
       }
     },
     "node_modules/react-is": {
@@ -3304,6 +3460,11 @@
       "integrity": "sha512-N+8UisAXDGk8PFXP4HAzVR9nbfmVJ3zYLAWiTIoqC5v5isinhr+r5uaO8+7r3BMfuNIufIsA7RdpVgacC2cSpw==",
       "dev": true
     },
+    "node_modules/tiny-warning": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/tiny-warning/-/tiny-warning-1.0.3.tgz",
+      "integrity": "sha512-lBN9zLN/oAf68o3zNXYrdCt1kP8WsiGW8Oo2ka41b2IM5JL/S1CTyX1rW0mb/zSuJun0ZUrDxx4sqvYS2FWzPA=="
+    },
     "node_modules/to-fast-properties": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/to-fast-properties/-/to-fast-properties-2.0.0.tgz",
@@ -3335,6 +3496,11 @@
       "peerDependencies": {
         "typescript": ">=4.2.0"
       }
+    },
+    "node_modules/tslib": {
+      "version": "2.7.0",
+      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.7.0.tgz",
+      "integrity": "sha512-gLXCKdN1/j47AiHiOkJN69hJmcbGTHI0ImLmbYLHykhgeN0jVGola9yVjFgzCUklsZQMW55o+dW7IXv3RCXDzA=="
     },
     "node_modules/type-check": {
       "version": "0.4.0",
@@ -3423,10 +3589,18 @@
         "punycode": "^2.1.0"
       }
     },
+    "node_modules/use-sync-external-store": {
+      "version": "1.2.2",
+      "resolved": "https://registry.npmjs.org/use-sync-external-store/-/use-sync-external-store-1.2.2.tgz",
+      "integrity": "sha512-PElTlVMwpblvbNqQ82d2n6RjStvdSoNe9FG28kNfz3WiXilJm4DdNkEzRhCZuIDwY8U08WVihhGR5iRqAwfDiw==",
+      "peerDependencies": {
+        "react": "^16.8.0 || ^17.0.0 || ^18.0.0"
+      }
+    },
     "node_modules/vite": {
-      "version": "5.4.3",
-      "resolved": "https://registry.npmjs.org/vite/-/vite-5.4.3.tgz",
-      "integrity": "sha512-IH+nl64eq9lJjFqU+/yrRnrHPVTlgy42/+IzbOdaFDVlyLgI/wDlf+FCobXLX1cT0X5+7LMyH1mIy2xJdLfo8Q==",
+      "version": "5.4.6",
+      "resolved": "https://registry.npmjs.org/vite/-/vite-5.4.6.tgz",
+      "integrity": "sha512-IeL5f8OO5nylsgzd9tq4qD2QqI0k2CQLGrWD0rCN0EQJZpBK5vJAx0I+GDkMOXxQX/OfFHMuLIx6ddAxGX/k+Q==",
       "dev": true,
       "dependencies": {
         "esbuild": "^0.21.3",
@@ -3530,6 +3704,33 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/zustand": {
+      "version": "4.5.5",
+      "resolved": "https://registry.npmjs.org/zustand/-/zustand-4.5.5.tgz",
+      "integrity": "sha512-+0PALYNJNgK6hldkgDq2vLrw5f6g/jCInz52n9RTpropGgeAf/ioFUCdtsjCqu4gNhW9D01rUQBROoRjdzyn2Q==",
+      "dependencies": {
+        "use-sync-external-store": "1.2.2"
+      },
+      "engines": {
+        "node": ">=12.7.0"
+      },
+      "peerDependencies": {
+        "@types/react": ">=16.8",
+        "immer": ">=9.0.6",
+        "react": ">=16.8"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        },
+        "immer": {
+          "optional": true
+        },
+        "react": {
+          "optional": true
+        }
       }
     }
   }

--- a/package.json
+++ b/package.json
@@ -15,11 +15,12 @@
     "@emotion/styled": "^11.13.0",
     "axios": "^1.7.7",
     "emotion": "^11.0.0",
+    "formik": "^2.4.6",
     "react": "^18.3.1",
     "react-dom": "^18.3.1",
-
     "react-icons": "^5.3.0",
     "react-router-dom": "^6.26.1",
+    "yup": "^1.4.0",
     "zustand": "^4.5.5"
   },
   "devDependencies": {

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -23,6 +23,9 @@ importers:
       emotion:
         specifier: ^11.0.0
         version: 11.0.0
+      formik:
+        specifier: ^2.4.6
+        version: 2.4.6(react@18.3.1)
       react:
         specifier: ^18.3.1
         version: 18.3.1
@@ -35,6 +38,9 @@ importers:
       react-router-dom:
         specifier: ^6.26.1
         version: 6.26.2(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+      yup:
+        specifier: ^1.4.0
+        version: 1.4.0
       zustand:
         specifier: ^4.5.5
         version: 4.5.5(@types/react@18.3.6)(react@18.3.1)
@@ -574,6 +580,9 @@ packages:
   '@types/estree@1.0.5':
     resolution: {integrity: sha512-/kYRxGDLWzHOB7q+wtSUQlFrtcdUccpfy+X+9iMBpHK8QLLhx2wIPYuS5DYtR9Wa/YlZAbIovy7qVdB1Aq6Lyw==}
 
+  '@types/hoist-non-react-statics@3.3.5':
+    resolution: {integrity: sha512-SbcrWzkKBw2cdwRTwQAswfpB9g9LJWfjtUeW/jvNwbhC8cpmmNYVePa+ncbUe0rGTQ7G3Ff6mYUN2VMfLVr+Sg==}
+
   '@types/parse-json@4.0.2':
     resolution: {integrity: sha512-dISoDXWWQwUquiKsyZ4Ng+HX2KsPL7LyHKHQwgGFEA3IaKac4Obd+h2a/a6waisAoepJlBcx9paWqjA8/HVjCw==}
 
@@ -769,6 +778,10 @@ packages:
   deep-is@0.1.4:
     resolution: {integrity: sha512-oIPzksmTg4/MriiaYGO+okXDT7ztn/w3Eptv/+gSIdMdKsJo0u4CfYNFJPy+4SKMuCqGw2wxnA+URMg3t8a/bQ==}
 
+  deepmerge@2.2.1:
+    resolution: {integrity: sha512-R9hc1Xa/NOBi9WRVUWg19rl1UB7Tt4kuPd+thNJgFZoxXsTz7ncaPaeIm+40oSGuP33DfMb4sZt1QIGiJzC4EA==}
+    engines: {node: '>=0.10.0'}
+
   delayed-stream@1.0.0:
     resolution: {integrity: sha512-ZySD7Nf91aLB0RxL4KGrKHBXl7Eds1DAmEdcoVawXnLD7SDhpNgtuII2aAkg7a7QS41jxPSZ17p4VdGnMHk3MQ==}
     engines: {node: '>=0.4.0'}
@@ -903,6 +916,11 @@ packages:
     resolution: {integrity: sha512-ETEklSGi5t0QMZuiXoA/Q6vcnxcLQP5vdugSpuAyi6SVGi2clPPp+xgEhuMaHC+zGgn31Kd235W35f7Hykkaww==}
     engines: {node: '>= 6'}
 
+  formik@2.4.6:
+    resolution: {integrity: sha512-A+2EI7U7aG296q2TLGvNapDNTZp1khVt5Vk0Q/fyfSROss0V/V6+txt2aJnwEos44IxTCW/LYAi/zgWzlevj+g==}
+    peerDependencies:
+      react: '>=16.8.0'
+
   fsevents@2.3.3:
     resolution: {integrity: sha512-5xoDfX+fL7faATnagmWPpbFtwh/R77WmMMqqHGS65C3vvB0YHrgF+B1YmZ3441tMj5n63k0212XNoJwzlhffQw==}
     engines: {node: ^8.16.0 || ^10.6.0 || >=11.0.0}
@@ -1034,8 +1052,14 @@ packages:
     resolution: {integrity: sha512-iPZK6eYjbxRu3uB4/WZ3EsEIMJFMqAoopl3R+zuq0UjcAm/MO6KCweDgPfP3elTztoKP3KtnVHxTn2NHBSDVUw==}
     engines: {node: '>=10'}
 
+  lodash-es@4.17.21:
+    resolution: {integrity: sha512-mKnC+QJ9pWVzv+C4/U3rRsHapFfHvQFoFB92e52xeyGMcX6/OlIl78je1u8vePzYZSkkogMPJ2yjxxsb89cxyw==}
+
   lodash.merge@4.6.2:
     resolution: {integrity: sha512-0KpjqXRVvrYyCsX1swR/XTK0va6VQkQM6MNo7PqW77ByjAhoARA8EfrP1N4+KlKj8YS0ZUCtRT/YUuhyYDujIQ==}
+
+  lodash@4.17.21:
+    resolution: {integrity: sha512-v2kDEe57lecTulaDIuNTPy3Ry4gLGJ6Z1O3vE1krgXZNrsQ+LFTGHVxVjcXPs17LhbZVGedAJv8XZ1tvj5FvSg==}
 
   loose-envify@1.4.0:
     resolution: {integrity: sha512-lyuxPGr/Wfhrlem2CL/UcnUc1zcqKAImBDzukY7Y5F/yQiNdko6+fRLevlw1HgMySw7f611UIY408EtxRSoK3Q==}
@@ -1131,6 +1155,9 @@ packages:
     resolution: {integrity: sha512-vkcDPrRZo1QZLbn5RLGPpg/WmIQ65qoWWhcGKf/b5eplkkarX0m9z8ppCat4mlOqUsWpyNuYgO3VRyrYHSzX5g==}
     engines: {node: '>= 0.8.0'}
 
+  property-expr@2.0.6:
+    resolution: {integrity: sha512-SVtmxhRE/CGkn3eZY1T6pC8Nln6Fr/lu1mKSgRud0eC73whjGfoAogbn78LkD8aFL0zz3bAFerKSnOl7NlErBA==}
+
   proxy-from-env@1.1.0:
     resolution: {integrity: sha512-D+zkORCbA9f1tdWRK0RaCR3GPv50cMxcrz4X8k5LTSUD1Dkw47mKJEZQNunItRTkWwgtaUSo1RVFRIG9ZXiFYg==}
 
@@ -1145,6 +1172,9 @@ packages:
     resolution: {integrity: sha512-5m4nQKp+rZRb09LNH59GM4BxTh9251/ylbKIbpe7TpGxfJ+9kv6BLkLBXIjjspbgbnIBNqlI23tRnTWT0snUIw==}
     peerDependencies:
       react: ^18.3.1
+
+  react-fast-compare@2.0.4:
+    resolution: {integrity: sha512-suNP+J1VU1MWFKcyt7RtjiSWUjvidmQSlqu+eHslq+342xCbGTYmC0mEhPCOHxlW0CywylOC1u2DFAT+bv4dBw==}
 
   react-icons@5.3.0:
     resolution: {integrity: sha512-DnUk8aFbTyQPSkCfF8dbX6kQjXA9DktMeJqfjrg6cK9vwQVMxmcA3BfP4QoiztVmEHtwlTgLFsPuH2NskKT6eg==}
@@ -1252,6 +1282,12 @@ packages:
   text-table@0.2.0:
     resolution: {integrity: sha512-N+8UisAXDGk8PFXP4HAzVR9nbfmVJ3zYLAWiTIoqC5v5isinhr+r5uaO8+7r3BMfuNIufIsA7RdpVgacC2cSpw==}
 
+  tiny-case@1.0.3:
+    resolution: {integrity: sha512-Eet/eeMhkO6TX8mnUteS9zgPbUMQa4I6Kkp5ORiBD5476/m+PIRiumP5tmh5ioJpH7k51Kehawy2UDfsnxxY8Q==}
+
+  tiny-warning@1.0.3:
+    resolution: {integrity: sha512-lBN9zLN/oAf68o3zNXYrdCt1kP8WsiGW8Oo2ka41b2IM5JL/S1CTyX1rW0mb/zSuJun0ZUrDxx4sqvYS2FWzPA==}
+
   to-fast-properties@2.0.0:
     resolution: {integrity: sha512-/OaKK0xYrs3DmxRYqL/yDc+FxFUVYhDlXMhRmv3z915w2HF1tnN1omB354j8VUGO/hbRzyD6Y3sA7v7GS/ceog==}
     engines: {node: '>=4'}
@@ -1260,15 +1296,25 @@ packages:
     resolution: {integrity: sha512-65P7iz6X5yEr1cwcgvQxbbIw7Uk3gOy5dIdtZ4rDveLqhrdJP+Li/Hx6tyK0NEb+2GCyneCMJiGqrADCSNk8sQ==}
     engines: {node: '>=8.0'}
 
+  toposort@2.0.2:
+    resolution: {integrity: sha512-0a5EOkAUp8D4moMi2W8ZF8jcga7BgZd91O/yabJCFY8az+XSzeGyTKs0Aoo897iV1Nj6guFq8orWDS96z91oGg==}
+
   ts-api-utils@1.3.0:
     resolution: {integrity: sha512-UQMIo7pb8WRomKR1/+MFVLTroIvDVtMX3K6OUir8ynLyzB8Jeriont2bTAtmNPa1ekAgN7YPDyf6V+ygrdU+eQ==}
     engines: {node: '>=16'}
     peerDependencies:
       typescript: '>=4.2.0'
 
+  tslib@2.7.0:
+    resolution: {integrity: sha512-gLXCKdN1/j47AiHiOkJN69hJmcbGTHI0ImLmbYLHykhgeN0jVGola9yVjFgzCUklsZQMW55o+dW7IXv3RCXDzA==}
+
   type-check@0.4.0:
     resolution: {integrity: sha512-XleUoc9uwGXqjWwXaUTZAmzMcFZ5858QA2vvx1Ur5xIcixXIP+8LnFDgRplU30us6teqdlskFfu+ae4K79Ooew==}
     engines: {node: '>= 0.8.0'}
+
+  type-fest@2.19.0:
+    resolution: {integrity: sha512-RAH822pAdBgcNMAfWnCBU3CFZcfZ/i1eZjwFU/dsLKumyuuP3niueg2UAukXYF0E2AAoc82ZSSf9J0WQBinzHA==}
+    engines: {node: '>=12.20'}
 
   typescript-eslint@8.5.0:
     resolution: {integrity: sha512-uD+XxEoSIvqtm4KE97etm32Tn5MfaZWgWfMMREStLxR6JzvHkc2Tkj7zhTEK5XmtpTmKHNnG8Sot6qDfhHtR1Q==}
@@ -1348,6 +1394,9 @@ packages:
   yocto-queue@0.1.0:
     resolution: {integrity: sha512-rVksvsnNCdJ/ohGc6xgPwyN8eheCxsiLM8mxuE/t/mOVqJewPuO1miLpTHQiRgTKCLexL4MeAFVagts7HmNZ2Q==}
     engines: {node: '>=10'}
+
+  yup@1.4.0:
+    resolution: {integrity: sha512-wPbgkJRCqIf+OHyiTBQoJiP5PFuAXaWiJK6AmYkzQAh5/c2K9hzSApBZG5wV9KoKSePF7sAxmNSvh/13YHkFDg==}
 
   zustand@4.5.5:
     resolution: {integrity: sha512-+0PALYNJNgK6hldkgDq2vLrw5f6g/jCInz52n9RTpropGgeAf/ioFUCdtsjCqu4gNhW9D01rUQBROoRjdzyn2Q==}
@@ -1844,6 +1893,11 @@ snapshots:
 
   '@types/estree@1.0.5': {}
 
+  '@types/hoist-non-react-statics@3.3.5':
+    dependencies:
+      '@types/react': 18.3.6
+      hoist-non-react-statics: 3.3.2
+
   '@types/parse-json@4.0.2': {}
 
   '@types/prop-types@15.7.12': {}
@@ -2071,6 +2125,8 @@ snapshots:
 
   deep-is@0.1.4: {}
 
+  deepmerge@2.2.1: {}
+
   delayed-stream@1.0.0: {}
 
   electron-to-chromium@1.5.23: {}
@@ -2235,6 +2291,18 @@ snapshots:
       combined-stream: 1.0.8
       mime-types: 2.1.35
 
+  formik@2.4.6(react@18.3.1):
+    dependencies:
+      '@types/hoist-non-react-statics': 3.3.5
+      deepmerge: 2.2.1
+      hoist-non-react-statics: 3.3.2
+      lodash: 4.17.21
+      lodash-es: 4.17.21
+      react: 18.3.1
+      react-fast-compare: 2.0.4
+      tiny-warning: 1.0.3
+      tslib: 2.7.0
+
   fsevents@2.3.3:
     optional: true
 
@@ -2330,7 +2398,11 @@ snapshots:
     dependencies:
       p-locate: 5.0.0
 
+  lodash-es@4.17.21: {}
+
   lodash.merge@4.6.2: {}
+
+  lodash@4.17.21: {}
 
   loose-envify@1.4.0:
     dependencies:
@@ -2417,6 +2489,8 @@ snapshots:
 
   prelude-ls@1.2.1: {}
 
+  property-expr@2.0.6: {}
+
   proxy-from-env@1.1.0: {}
 
   punycode@2.3.1: {}
@@ -2428,6 +2502,8 @@ snapshots:
       loose-envify: 1.4.0
       react: 18.3.1
       scheduler: 0.23.2
+
+  react-fast-compare@2.0.4: {}
 
   react-icons@5.3.0(react@18.3.1):
     dependencies:
@@ -2529,19 +2605,29 @@ snapshots:
 
   text-table@0.2.0: {}
 
+  tiny-case@1.0.3: {}
+
+  tiny-warning@1.0.3: {}
+
   to-fast-properties@2.0.0: {}
 
   to-regex-range@5.0.1:
     dependencies:
       is-number: 7.0.0
 
+  toposort@2.0.2: {}
+
   ts-api-utils@1.3.0(typescript@5.6.2):
     dependencies:
       typescript: 5.6.2
 
+  tslib@2.7.0: {}
+
   type-check@0.4.0:
     dependencies:
       prelude-ls: 1.2.1
+
+  type-fest@2.19.0: {}
 
   typescript-eslint@8.5.0(eslint@9.10.0)(typescript@5.6.2):
     dependencies:
@@ -2589,6 +2675,13 @@ snapshots:
   yaml@1.10.2: {}
 
   yocto-queue@0.1.0: {}
+
+  yup@1.4.0:
+    dependencies:
+      property-expr: 2.0.6
+      tiny-case: 1.0.3
+      toposort: 2.0.2
+      type-fest: 2.19.0
 
   zustand@4.5.5(@types/react@18.3.6)(react@18.3.1):
     dependencies:

--- a/src/components/LoginForm.tsx
+++ b/src/components/LoginForm.tsx
@@ -46,8 +46,7 @@ const Error = styled.div`
   letter-spacing: -0.011em;
   color: #ff0000;
   min-height: 24px;
-  margin-top: -30px;
-  margin-bottom: 35px;
+  text-align: center;
 `
 const LoginForm = () => {
   const navigate = useNavigate()
@@ -75,7 +74,6 @@ const LoginForm = () => {
         onChange={formik.handleChange}
         onBlur={formik.handleBlur}
       ></InputForm>
-
       <FormLabel>비밀번호</FormLabel>
       <InputForm
         type="password"
@@ -94,7 +92,14 @@ const LoginForm = () => {
         text="회원가입"
         isPrimary={false}
         onClick={() => navigate('/register')}
-      ></TextButton>
+      ></TextButton>{' '}
+      {error && (
+        <Error>
+          로그인에 실패했습니다.
+          <br />
+          아이디와 비밀번호를 다시 한 번 확인해 주세요.
+        </Error>
+      )}
     </Form>
   )
 }

--- a/src/components/LoginForm.tsx
+++ b/src/components/LoginForm.tsx
@@ -37,7 +37,18 @@ const InputForm = styled.input`
     caret-color: #ffa800;
   }
 `
-
+const Error = styled.div`
+  font-family: Inter;
+  font-style: normal;
+  font-size: 18px;
+  font-weight: 500;
+  line-height: 150%;
+  letter-spacing: -0.011em;
+  color: #ff0000;
+  min-height: 24px;
+  margin-top: -30px;
+  margin-bottom: 35px;
+`
 const LoginForm = () => {
   const navigate = useNavigate()
 
@@ -64,6 +75,7 @@ const LoginForm = () => {
         onChange={formik.handleChange}
         onBlur={formik.handleBlur}
       ></InputForm>
+
       <FormLabel>비밀번호</FormLabel>
       <InputForm
         type="password"

--- a/src/components/LoginForm.tsx
+++ b/src/components/LoginForm.tsx
@@ -1,8 +1,11 @@
 import styled from '@emotion/styled'
 import TextButton from './TextButton'
 import { useNavigate } from 'react-router-dom'
+import { useFormik } from 'formik'
+import { AuthRequest } from '../model/AuthRequest'
+import { useLogin } from '../hooks/useLogin'
 
-const Form = styled.div`
+const Form = styled.form`
   margin-bottom: 31px;
 `
 
@@ -37,13 +40,44 @@ const InputForm = styled.input`
 
 const LoginForm = () => {
   const navigate = useNavigate()
+
+  const { login, isLoading, error } = useLogin()
+  const formik = useFormik<AuthRequest>({
+    initialValues: {
+      nickname: '',
+      password: '',
+    },
+    onSubmit: (authRequest: AuthRequest) => {
+      console.log('auth request', authRequest)
+      login(authRequest)
+    },
+  })
+
   return (
-    <Form>
+    <Form onSubmit={formik.handleSubmit}>
       <FormLabel>닉네임</FormLabel>
-      <InputForm></InputForm>
+      <InputForm
+        type="nickname"
+        id="nickname"
+        name="nickname"
+        value={formik.values.nickname}
+        onChange={formik.handleChange}
+        onBlur={formik.handleBlur}
+      ></InputForm>
       <FormLabel>비밀번호</FormLabel>
-      <InputForm></InputForm>
-      <TextButton text="로그인" isPrimary={true}></TextButton>
+      <InputForm
+        type="password"
+        id="password"
+        name="password"
+        value={formik.values.password}
+        onChange={formik.handleChange}
+        onBlur={formik.handleBlur}
+      ></InputForm>
+      <TextButton
+        text="로그인"
+        isPrimary={true}
+        onClick={formik.handleSubmit}
+      ></TextButton>
       <TextButton
         text="회원가입"
         isPrimary={false}

--- a/src/components/LoginForm.tsx
+++ b/src/components/LoginForm.tsx
@@ -1,4 +1,6 @@
 import styled from '@emotion/styled'
+import TextButton from './TextButton'
+import { useNavigate } from 'react-router-dom'
 
 const Form = styled.div`
   margin-bottom: 31px;
@@ -34,12 +36,19 @@ const InputForm = styled.input`
 `
 
 const LoginForm = () => {
+  const navigate = useNavigate()
   return (
     <Form>
       <FormLabel>닉네임</FormLabel>
       <InputForm></InputForm>
       <FormLabel>비밀번호</FormLabel>
       <InputForm></InputForm>
+      <TextButton text="로그인" isPrimary={true}></TextButton>
+      <TextButton
+        text="회원가입"
+        isPrimary={false}
+        onClick={() => navigate('/register')}
+      ></TextButton>
     </Form>
   )
 }

--- a/src/components/RegisterForm.tsx
+++ b/src/components/RegisterForm.tsx
@@ -33,15 +33,17 @@ const InputForm = styled.input`
   }
 `
 
-const LoginForm = () => {
+const RegisterForm = () => {
   return (
     <Form>
       <FormLabel>닉네임</FormLabel>
       <InputForm></InputForm>
       <FormLabel>비밀번호</FormLabel>
       <InputForm></InputForm>
+      <FormLabel>비밀번호 재확인</FormLabel>
+      <InputForm></InputForm>
     </Form>
   )
 }
 
-export default LoginForm
+export default RegisterForm

--- a/src/components/RegisterForm.tsx
+++ b/src/components/RegisterForm.tsx
@@ -4,6 +4,7 @@ import { Profile } from '../model/Profile'
 import { useRegister } from '../hooks/useRegister'
 import TextButton from './TextButton'
 import profileValidationSchema from '../validation/profileValidationSchema'
+import { useNavigate } from 'react-router-dom'
 
 const Form = styled.form`
   margin-bottom: 31px;
@@ -39,6 +40,7 @@ const InputForm = styled.input<{ placeholder?: string }>`
 `
 
 const RegisterForm = () => {
+  const navigate = useNavigate()
   const { error, isLoading, signup, toast } = useRegister()
   const formik = useFormik<Profile>({
     initialValues: {
@@ -89,7 +91,11 @@ const RegisterForm = () => {
         isPrimary={false}
         onClick={formik.handleSubmit}
       ></TextButton>
-      <TextButton text="로그인" isPrimary={true}></TextButton>
+      <TextButton
+        text="로그인"
+        isPrimary={true}
+        onClick={() => navigate('/login')}
+      ></TextButton>
     </Form>
   )
 }

--- a/src/components/RegisterForm.tsx
+++ b/src/components/RegisterForm.tsx
@@ -127,6 +127,7 @@ const RegisterForm = () => {
           type="password"
           id="confirmPassword"
           name="confirmPassword"
+          value={formik.values.confirmPassword}
           onChange={formik.handleChange}
           onBlur={formik.handleBlur}
           hasError={
@@ -142,12 +143,12 @@ const RegisterForm = () => {
       ) : null}
       <TextButton
         text="회원가입"
-        isPrimary={false}
+        isPrimary={true}
         onClick={formik.handleSubmit}
       ></TextButton>
       <TextButton
         text="로그인"
-        isPrimary={true}
+        isPrimary={false}
         onClick={() => navigate('/login')}
       ></TextButton>
     </Form>

--- a/src/components/RegisterForm.tsx
+++ b/src/components/RegisterForm.tsx
@@ -5,12 +5,13 @@ import { useRegister } from '../hooks/useRegister'
 import TextButton from './TextButton'
 import profileValidationSchema from '../validation/profileValidationSchema'
 import { useNavigate } from 'react-router-dom'
+import { FaXmark } from 'react-icons/fa6'
 
 const Form = styled.form`
   margin-bottom: 31px;
 `
 
-const FormLabel = styled.label`
+const FormLabel = styled.label<{ marginTop?: string }>`
   color: #000000;
   font-family: Inter;
   font-style: normal;
@@ -19,10 +20,16 @@ const FormLabel = styled.label`
   display: block;
   margin-bottom: 8px;
 `
-const InputForm = styled.input<{ placeholder?: string }>`
+
+const InputWrapper = styled.div`
+  position: relative;
+  width: 100%;
+`
+
+const InputForm = styled.input<{ placeholder?: string; hasError: boolean }>`
   display: inline-block;
   background-color: #ededed;
-  border: none;
+  border: ${({ hasError }) => (hasError ? '1px solid #ff0000' : 'none')};
   border-radius: 5px;
   font-family: Inter;
   font-style: normal;
@@ -37,6 +44,28 @@ const InputForm = styled.input<{ placeholder?: string }>`
     outline: none;
     caret-color: #ffa800;
   }
+`
+
+const Error = styled.div`
+  font-family: Inter;
+  font-style: normal;
+  font-size: 18px;
+  font-weight: 500;
+  line-height: 150%;
+  letter-spacing: -0.011em;
+  color: #ff0000;
+  min-height: 24px;
+  margin-top: -30px;
+  margin-bottom: 35px;
+`
+
+const ErrorIcon = styled(FaXmark)`
+  position: absolute;
+  width: 30px;
+  height: 30px;
+  right: 15px;
+  top: 15px;
+  color: #ff0000;
 `
 
 const RegisterForm = () => {
@@ -60,32 +89,57 @@ const RegisterForm = () => {
   return (
     <Form onSubmit={formik.handleSubmit}>
       <FormLabel>닉네임</FormLabel>
-      <InputForm
-        type="nickname"
-        id="nickname"
-        placeholder="30자 이내로 작성해주시길 바랍니다."
-        name="nickname"
-        value={formik.values.nickname}
-        onChange={formik.handleChange}
-        onBlur={formik.handleBlur}
-      ></InputForm>
+      <InputWrapper>
+        <InputForm
+          type="nickname"
+          id="nickname"
+          placeholder="30자 이내로 작성해주시길 바랍니다."
+          name="nickname"
+          value={formik.values.nickname}
+          onChange={formik.handleChange}
+          onBlur={formik.handleBlur}
+          hasError={!!(formik.touched.nickname && formik.errors.nickname)}
+        />{' '}
+        {formik.touched.nickname && formik.errors.nickname && <ErrorIcon />}
+      </InputWrapper>
+      {formik.touched.nickname && formik.errors.nickname ? (
+        <Error>{formik.errors.nickname}</Error>
+      ) : null}
       <FormLabel>비밀번호</FormLabel>
-      <InputForm
-        type="password"
-        id="password"
-        name="password"
-        value={formik.values.password}
-        onChange={formik.handleChange}
-        onBlur={formik.handleBlur}
-      ></InputForm>
+      <InputWrapper>
+        <InputForm
+          type="password"
+          id="password"
+          name="password"
+          value={formik.values.password}
+          onChange={formik.handleChange}
+          onBlur={formik.handleBlur}
+          hasError={!!(formik.touched.password && formik.errors.password)}
+        />{' '}
+        {formik.touched.password && formik.errors.password && <ErrorIcon />}
+      </InputWrapper>
+      {formik.touched.password && formik.errors.password ? (
+        <Error>{formik.errors.password}</Error>
+      ) : null}
       <FormLabel>비밀번호 재확인</FormLabel>
-      <InputForm
-        type="password"
-        id="confirmPassword"
-        name="confirmPassword"
-        onChange={formik.handleChange}
-        onBlur={formik.handleBlur}
-      ></InputForm>
+      <InputWrapper>
+        <InputForm
+          type="password"
+          id="confirmPassword"
+          name="confirmPassword"
+          onChange={formik.handleChange}
+          onBlur={formik.handleBlur}
+          hasError={
+            !!(formik.touched.confirmPassword && formik.errors.confirmPassword)
+          }
+        />{' '}
+        {formik.touched.confirmPassword && formik.errors.confirmPassword && (
+          <ErrorIcon />
+        )}
+      </InputWrapper>
+      {formik.touched.confirmPassword && formik.errors.confirmPassword ? (
+        <Error>{formik.errors.confirmPassword}</Error>
+      ) : null}
       <TextButton
         text="회원가입"
         isPrimary={false}

--- a/src/components/RegisterForm.tsx
+++ b/src/components/RegisterForm.tsx
@@ -1,6 +1,11 @@
 import styled from '@emotion/styled'
+import { useFormik } from 'formik'
+import { Profile } from '../model/Profile'
+import { useRegister } from '../hooks/useRegister'
+import TextButton from './TextButton'
+import profileValidationSchema from '../validation/profileValidationSchema'
 
-const Form = styled.div`
+const Form = styled.form`
   margin-bottom: 31px;
 `
 
@@ -13,7 +18,7 @@ const FormLabel = styled.label`
   display: block;
   margin-bottom: 8px;
 `
-const InputForm = styled.input`
+const InputForm = styled.input<{ placeholder?: string }>`
   display: inline-block;
   background-color: #ededed;
   border: none;
@@ -34,14 +39,57 @@ const InputForm = styled.input`
 `
 
 const RegisterForm = () => {
+  const { error, isLoading, signup, toast } = useRegister()
+  const formik = useFormik<Profile>({
+    initialValues: {
+      nickname: '',
+      password: '',
+      confirmPassword: '',
+    },
+    validationSchema: profileValidationSchema,
+    onSubmit: (profile: Profile, { resetForm }) => {
+      const { confirmPassword, ...profileData } = profile
+      console.log(profileData)
+      signup(profileData)
+      resetForm()
+    },
+  })
+
   return (
-    <Form>
+    <Form onSubmit={formik.handleSubmit}>
       <FormLabel>닉네임</FormLabel>
-      <InputForm></InputForm>
+      <InputForm
+        type="nickname"
+        id="nickname"
+        placeholder="30자 이내로 작성해주시길 바랍니다."
+        name="nickname"
+        value={formik.values.nickname}
+        onChange={formik.handleChange}
+        onBlur={formik.handleBlur}
+      ></InputForm>
       <FormLabel>비밀번호</FormLabel>
-      <InputForm></InputForm>
+      <InputForm
+        type="password"
+        id="password"
+        name="password"
+        value={formik.values.password}
+        onChange={formik.handleChange}
+        onBlur={formik.handleBlur}
+      ></InputForm>
       <FormLabel>비밀번호 재확인</FormLabel>
-      <InputForm></InputForm>
+      <InputForm
+        type="password"
+        id="confirmPassword"
+        name="confirmPassword"
+        onChange={formik.handleChange}
+        onBlur={formik.handleBlur}
+      ></InputForm>
+      <TextButton
+        text="회원가입"
+        isPrimary={false}
+        onClick={formik.handleSubmit}
+      ></TextButton>
+      <TextButton text="로그인" isPrimary={true}></TextButton>
     </Form>
   )
 }

--- a/src/components/TextButton.tsx
+++ b/src/components/TextButton.tsx
@@ -24,7 +24,7 @@ const Button = styled.button<{ isPrimary?: boolean }>`
 
 const TextButton = ({ text, isPrimary, onClick }: Props) => {
   return (
-    <Button isPrimary={isPrimary} onClick={onClick}>
+    <Button isPrimary={isPrimary} onClick={onClick} type="submit">
       {text}
     </Button>
   )

--- a/src/config/api-client.ts
+++ b/src/config/api-client.ts
@@ -1,0 +1,22 @@
+import axios from 'axios'
+import { AuthResponse } from '../model/AuthResponse'
+
+const apiClient = axios.create({
+  baseURL: 'http://211.188.49.236:5252/api/v1',
+})
+
+apiClient.interceptors.request.use(
+  (config) => {
+    if (!config.url?.includes('/login') && !config.url?.includes('/signup')) {
+      const authObject = localStorage.getItem('user')
+      if (authObject) {
+        const { accessToken } = JSON.parse(authObject) as AuthResponse
+        config.headers.Authorization = `Bearer ${accessToken}`
+      }
+    }
+    return config
+  },
+  (error) => Promise.reject(error)
+)
+
+export default apiClient

--- a/src/context/AuthContext.tsx
+++ b/src/context/AuthContext.tsx
@@ -1,0 +1,30 @@
+import { createContext, ReactNode, useEffect, useState } from 'react'
+
+interface AuthContextType {
+  isAuthenticated: boolean
+  updateAuth: (flag: boolean) => void
+}
+
+export const AuthContext = createContext<AuthContextType | undefined>(undefined)
+
+export const AuthContextProvider: React.FC<{ children: ReactNode }> = ({
+  children,
+}) => {
+  const [isAuthenticated, setAuthenticated] = useState<boolean>(false)
+  const updateAuth = (flag: boolean) => {
+    setAuthenticated(flag)
+  }
+
+  useEffect(() => {
+    const authObject = localStorage.getItem('user')
+    if (authObject) {
+      setAuthenticated(true)
+    }
+  }, [])
+
+  return (
+    <AuthContext.Provider value={{ isAuthenticated, updateAuth }}>
+      {children}
+    </AuthContext.Provider>
+  )
+}

--- a/src/hooks/useAuthContext.ts
+++ b/src/hooks/useAuthContext.ts
@@ -1,0 +1,12 @@
+import { useContext } from 'react'
+import { AuthContext } from '../context/AuthContext'
+
+export const useAuthContext = () => {
+  const context = useContext(AuthContext)
+
+  if (!context) {
+    throw new Error('Context is not available')
+  }
+
+  return context
+}

--- a/src/hooks/useLogin.ts
+++ b/src/hooks/useLogin.ts
@@ -1,0 +1,34 @@
+import { authenticate } from './../services/auth-service'
+import { useState } from 'react'
+import { useNavigate } from 'react-router-dom'
+import { AuthRequest } from '../model/AuthRequest'
+import { useAuthContext } from './useAuthContext'
+
+export const useLogin = () => {
+  const [error, setError] = useState<string>('')
+  const [isLoading, setLoader] = useState<boolean>(false)
+  const navigate = useNavigate()
+  const { updateAuth } = useAuthContext()
+  const login = (authRequest: AuthRequest) => {
+    setLoader(true)
+    authenticate(authRequest)
+      .then((response) => {
+        localStorage.setItem('user', JSON.stringify(response.data))
+        updateAuth(true)
+        navigate('/')
+      })
+      .catch((error) => {
+        if (
+          error.response &&
+          error.response.data &&
+          error.response.data.message
+        ) {
+          setError(error.response.data.message)
+        } else {
+          setError(error.message)
+        }
+      })
+      .finally(() => setLoader(false))
+  }
+  return { error, isLoading, login }
+}

--- a/src/hooks/useLogin.ts
+++ b/src/hooks/useLogin.ts
@@ -13,9 +13,9 @@ export const useLogin = () => {
     setLoader(true)
     authenticate(authRequest)
       .then((response) => {
-        localStorage.setItem('user', JSON.stringify(response.data))
+        localStorage.setItem('user', JSON.stringify(response.data.accessToken))
         updateAuth(true)
-        navigate('/')
+        navigate('/search')
       })
       .catch((error) => {
         if (

--- a/src/hooks/useRegister.ts
+++ b/src/hooks/useRegister.ts
@@ -1,17 +1,20 @@
 import { useState } from 'react'
 import { createProfile } from '../services/auth-service'
 import { AuthRequest } from '../model/AuthRequest'
+import { useNavigate } from 'react-router-dom'
 
 export const useRegister = () => {
   const [error, setError] = useState<string>('')
   const [isLoading, setLoader] = useState<boolean>(false)
   const [toast, setToast] = useState<string>('')
+  const navigate = useNavigate()
   const signup = (profile: AuthRequest) => {
     setLoader(true)
     createProfile(profile)
       .then((response) => {
         if (response && response.status === 201) {
           setToast('Profile is successfully created')
+          navigate('/login')
         }
       })
       .catch((error) => setError(error.message))

--- a/src/hooks/useRegister.ts
+++ b/src/hooks/useRegister.ts
@@ -1,0 +1,21 @@
+import { useState } from 'react'
+import { createProfile } from '../services/auth-service'
+import { AuthRequest } from '../model/AuthRequest'
+
+export const useRegister = () => {
+  const [error, setError] = useState<string>('')
+  const [isLoading, setLoader] = useState<boolean>(false)
+  const [toast, setToast] = useState<string>('')
+  const signup = (profile: AuthRequest) => {
+    setLoader(true)
+    createProfile(profile)
+      .then((response) => {
+        if (response && response.status === 201) {
+          setToast('Profile is successfully created')
+        }
+      })
+      .catch((error) => setError(error.message))
+      .finally(() => setLoader(false))
+  }
+  return { error, isLoading, signup, toast }
+}

--- a/src/main.tsx
+++ b/src/main.tsx
@@ -7,6 +7,7 @@ import Home from './pages/home.tsx'
 import Login from './pages/Login.tsx'
 import Register from './pages/Register.tsx'
 import Search from './pages/search.tsx'
+import { AuthContextProvider } from './context/AuthContext.tsx'
 
 const router = createBrowserRouter([
   { path: '/home', element: <Home /> },
@@ -17,6 +18,8 @@ const router = createBrowserRouter([
 
 createRoot(document.getElementById('root')!).render(
   <StrictMode>
-    <RouterProvider router={router} />
+    <AuthContextProvider>
+      <RouterProvider router={router} />
+    </AuthContextProvider>
   </StrictMode>
 )

--- a/src/model/AuthRequest.ts
+++ b/src/model/AuthRequest.ts
@@ -1,0 +1,4 @@
+export interface AuthRequest {
+  nickname: string
+  password: string
+}

--- a/src/model/AuthResponse.ts
+++ b/src/model/AuthResponse.ts
@@ -1,0 +1,4 @@
+export interface AuthResponse {
+  accessToken: string
+  refreshToken: string
+}

--- a/src/model/Profile.ts
+++ b/src/model/Profile.ts
@@ -1,4 +1,5 @@
 export interface Profile {
   nickname: string
   password: string
+  confirmPassword: string
 }

--- a/src/model/Profile.ts
+++ b/src/model/Profile.ts
@@ -1,0 +1,4 @@
+export interface Profile {
+  nickname: string
+  password: string
+}

--- a/src/model/ProfileResponse.ts
+++ b/src/model/ProfileResponse.ts
@@ -1,0 +1,3 @@
+export interface ProfileResponse {
+  id: number
+}

--- a/src/pages/Login.tsx
+++ b/src/pages/Login.tsx
@@ -20,8 +20,7 @@ const Login = () => {
       <div>
         <img src="../src/assets/images/logo.svg"></img>
         <FormWrapper>
-          <LoginForm title="닉네임" marginBottom="35Px"></LoginForm>
-          <LoginForm title="비밀번호" marginBottom="66Px"></LoginForm>
+          <LoginForm></LoginForm>
           <TextButton text="로그인" isPrimary={true}></TextButton>
           <TextButton text="회원가입" isPrimary={false}></TextButton>
         </FormWrapper>

--- a/src/pages/Login.tsx
+++ b/src/pages/Login.tsx
@@ -1,7 +1,6 @@
 import styled from '@emotion/styled'
 import LoginForm from '../components/LoginForm'
 import Background from '../components/Background'
-import TextButton from '../components/TextButton'
 
 const Container = styled.div`
   display: flex;
@@ -9,7 +8,7 @@ const Container = styled.div`
   align-items: center;
   height: 100vh;
 `
-const FormWrapper = styled.form`
+const FormWrapper = styled.div`
   width: 417px;
 `
 

--- a/src/pages/Login.tsx
+++ b/src/pages/Login.tsx
@@ -21,8 +21,6 @@ const Login = () => {
         <img src="../src/assets/images/logo.svg"></img>
         <FormWrapper>
           <LoginForm></LoginForm>
-          <TextButton text="로그인" isPrimary={true}></TextButton>
-          <TextButton text="회원가입" isPrimary={false}></TextButton>
         </FormWrapper>
       </div>
     </Container>

--- a/src/pages/Register.tsx
+++ b/src/pages/Register.tsx
@@ -1,7 +1,10 @@
 import styled from '@emotion/styled'
-import LoginForm from '../components/LoginForm'
 import Background from '../components/Background'
 import TextButton from '../components/TextButton'
+import { useRegister } from '../hooks/useRegister'
+import { Profile } from '../model/Profile'
+import { useFormik } from 'formik'
+import RegisterForm from '../components/RegisterForm'
 
 const Container = styled.div`
   display: flex;
@@ -14,15 +17,29 @@ const FormWrapper = styled.form`
 `
 
 const Register = () => {
+  const { error, isLoading, signup, toast } = useRegister()
+  const formik = useFormik<Profile>({
+    initialValues: {
+      nickname: '',
+      password: '',
+      confirmPassword: '',
+    },
+    onSubmit: (profile: Profile, { resetForm }) => {
+      signup(profile)
+      resetForm()
+    },
+  })
+
   return (
     <Container>
       <Background></Background>
       <div>
         <img src="../src/assets/images/logo.svg"></img>
         <FormWrapper>
-          <LoginForm title="닉네임" marginBottom="35Px"></LoginForm>
-          <LoginForm title="비밀번호" marginBottom="35Px"></LoginForm>
-          <LoginForm title="비밀번호 재확인" marginBottom="66Px"></LoginForm>
+          {isLoading && <p>Loading...</p>}
+          {error && <p>{error}</p>}
+          {toast && <p>{toast}</p>}
+          <RegisterForm></RegisterForm>
           <TextButton text="로그인" isPrimary={true}></TextButton>
           <TextButton text="회원가입" isPrimary={false}></TextButton>
         </FormWrapper>

--- a/src/pages/Register.tsx
+++ b/src/pages/Register.tsx
@@ -1,9 +1,5 @@
 import styled from '@emotion/styled'
 import Background from '../components/Background'
-import TextButton from '../components/TextButton'
-import { useRegister } from '../hooks/useRegister'
-import { Profile } from '../model/Profile'
-import { useFormik } from 'formik'
 import RegisterForm from '../components/RegisterForm'
 
 const Container = styled.div`
@@ -12,36 +8,18 @@ const Container = styled.div`
   align-items: center;
   height: 100vh;
 `
-const FormWrapper = styled.form`
+const FormWrapper = styled.div`
   width: 417px;
 `
 
 const Register = () => {
-  const { error, isLoading, signup, toast } = useRegister()
-  const formik = useFormik<Profile>({
-    initialValues: {
-      nickname: '',
-      password: '',
-      confirmPassword: '',
-    },
-    onSubmit: (profile: Profile, { resetForm }) => {
-      signup(profile)
-      resetForm()
-    },
-  })
-
   return (
     <Container>
       <Background></Background>
       <div>
         <img src="../src/assets/images/logo.svg"></img>
         <FormWrapper>
-          {isLoading && <p>Loading...</p>}
-          {error && <p>{error}</p>}
-          {toast && <p>{toast}</p>}
           <RegisterForm></RegisterForm>
-          <TextButton text="로그인" isPrimary={true}></TextButton>
-          <TextButton text="회원가입" isPrimary={false}></TextButton>
         </FormWrapper>
       </div>
     </Container>

--- a/src/services/auth-service.ts
+++ b/src/services/auth-service.ts
@@ -8,5 +8,5 @@ export const createProfile = (profile: AuthRequest) => {
 }
 
 export const authenticate = (authRequest: AuthRequest) => {
-  return apiClient.post<AuthResponse>('/users/login', authRequest)
+  return apiClient.post<AuthResponse>('/login', authRequest)
 }

--- a/src/services/auth-service.ts
+++ b/src/services/auth-service.ts
@@ -1,0 +1,12 @@
+import apiClient from '../config/api-client'
+import { AuthRequest } from '../model/AuthRequest'
+import { AuthResponse } from '../model/AuthResponse'
+import { Profile } from '../model/Profile'
+
+export const createProfile = (profile: Profile) => {
+  return apiClient.post<Profile>('/register', profile)
+}
+
+export const authenticate = (authRequest: AuthRequest) => {
+  return apiClient.post<AuthResponse>('/login', authRequest)
+}

--- a/src/services/auth-service.ts
+++ b/src/services/auth-service.ts
@@ -1,12 +1,12 @@
 import apiClient from '../config/api-client'
 import { AuthRequest } from '../model/AuthRequest'
 import { AuthResponse } from '../model/AuthResponse'
-import { Profile } from '../model/Profile'
+import { ProfileResponse } from '../model/ProfileResponse'
 
-export const createProfile = (profile: Profile) => {
-  return apiClient.post<Profile>('/register', profile)
+export const createProfile = (profile: AuthRequest) => {
+  return apiClient.post<ProfileResponse>('/users/signup', profile)
 }
 
 export const authenticate = (authRequest: AuthRequest) => {
-  return apiClient.post<AuthResponse>('/login', authRequest)
+  return apiClient.post<AuthResponse>('/users/login', authRequest)
 }

--- a/src/validation/profileValidationSchema.ts
+++ b/src/validation/profileValidationSchema.ts
@@ -2,7 +2,12 @@ import * as yup from 'yup'
 
 const profileValidationSchema = yup.object().shape({
   nickname: yup.string().required('이름을 입력하세요'),
-  password: yup.string().required('비밀번호를 입력하세요'),
+  password: yup
+    .string()
+    .required('비밀번호를 입력하세요')
+    .min(8, '비밀번호는 최소 8자리 이상이어야 합니다')
+    .matches(/[a-zA-Z]/, '비밀번호에는 영문자가 포함되어야 합니다')
+    .matches(/[0-9]/, '비밀번호에는 숫자가 포함되어야 합니다'),
   confirmPassword: yup
     .string()
     .required('비밀번호를 다시 입력하세요')

--- a/src/validation/profileValidationSchema.ts
+++ b/src/validation/profileValidationSchema.ts
@@ -1,0 +1,12 @@
+import * as yup from 'yup'
+
+const profileValidationSchema = yup.object().shape({
+  nickname: yup.string().required('이름을 입력하세요'),
+  password: yup.string().required('비밀번호를 입력하세요'),
+  confirmPassword: yup
+    .string()
+    .required('비밀번호를 다시 입력하세요')
+    .oneOf([yup.ref('password')], '입력을 재확인 해주세요'),
+})
+
+export default profileValidationSchema


### PR DESCRIPTION
## #️⃣연관된 이슈

> #2 

## 📝작업 내용

- 회원가입 및 로그인 기능 추가
- Register form과 login form component 분리
- Validation schema를 통하여 입력 검증 기능 구현
- Access Token 저장 및 사용 기능 추가
- 회원가입 및 로그인 테스트 완료

+회원가입 중복 체크를 서버에서 수행하지 않고있습니다. 해당 부분 한음님께 말씀드리겠습니다.

### 파일 구조
**model**을 통해서 데이터 전달 구조를 정의합니다
**service**를 통해서 실제 api endpoint에 접근합니다
components에서는 **custom hook**을 통해서 해당 비즈니스 로직을 사용합니다.

api-client.ts 파일을 통하여 api를 호출합니다.
해당 config를 통해서 login과 register를 제외한 api를 호출하는 경우 token을 가져와서 사용합니다.

AuthContext로 글로벌하게 인증 상태를 관리합니다.
 나중에 아래와 같이 루트 설정에 사용할 수도 있습니다.
```
<Route
   path="/"
   element={
   isAuthenticated ? <Home/> : <Navigate to="/login" />
   }
></Route>
```

<img width="1856" alt="image" src="https://github.com/user-attachments/assets/b1cc6d79-4b67-4182-bfe7-4a6d36ec3950">

### 추가된 패키지
1. formik (폼 입력 관리에 사용)
2. yup (폼 입력 검증에 사용)

## 💬리뷰 요구사항(선택)
> hook에 실제로 컴포넌트에서 사용하지 않는 요소들 (error와 isLoading 등)이 있는데 기본적인 기능이라 우선은 넣었습니다!
원래 로그인이랑 회원가입 pr을 따로 드리려고 했는데 마감 시간이 부족하다보니 한 번에 올렸습니다...! 양해부탁드립니다



