### PR TITLE
[FEAT] search and create family

### DIFF
--- a/src/components/FamilySheet.tsx
+++ b/src/components/FamilySheet.tsx
@@ -8,6 +8,8 @@ import { useEffect, useRef } from 'react'
 import { TiMinus, TiPlus } from 'react-icons/ti'
 import useProfiles from '../hooks/useProfiles'
 import ProfileCard from './ProfileCard'
+import useProfileIdState from '../stores/userProfileStore'
+import useProfileState from '../stores/userProfileStore'
 
 const FaimlySheet = () => {
   const isSearchBoxOpen = useSearchStore((state) => state.isOpen)
@@ -21,6 +23,10 @@ const FaimlySheet = () => {
   const boxRef = useRef<HTMLDivElement | null>(null)
   const searchRef = useRef<HTMLDivElement | null>(null)
   const popupRef = useRef<HTMLDivElement | null>(null)
+
+  const selectedProfiles = useProfileState((state) => state.contents)
+  const addProfile = useProfileState((state) => state.addProfile)
+  const removeProfile = useProfileState((state) => state.removeProfile)
 
   const { profiles, error, isLoading, setCurrentProfiles } = useProfiles()
 
@@ -52,7 +58,6 @@ const FaimlySheet = () => {
         <SearchBar
           onClick={openSearchBox}
           onChange={(e) => {
-            console.log('Input value:', e.target.value)
             setCurrentProfiles(e.target.value)
           }}
         ></SearchBar>
@@ -64,14 +69,24 @@ const FaimlySheet = () => {
               key={profile.id}
               profile={profile}
               icon={TiPlus}
+              onClick={() => {
+                addProfile(profile)
+              }}
             ></ProfileCard>
           ))}
         </Box>
       )}
       <Sheet>
-        {/* {items.map((item, index) => (
-          <ProfileCard nickname={item} key={index} icon={TiMinus}></ProfileCard>
-        ))} */}
+        {selectedProfiles.map((profile, index) => (
+          <ProfileCard
+            profile={profile}
+            key={index}
+            icon={TiMinus}
+            onClick={() => {
+              removeProfile(profile.id)
+            }}
+          ></ProfileCard>
+        ))}
       </Sheet>
       <TextButtonWrapper>
         <TextButton

--- a/src/components/FamilySheet.tsx
+++ b/src/components/FamilySheet.tsx
@@ -2,11 +2,94 @@ import styled from '@emotion/styled'
 import SearchBar from './SearchBar'
 import TextButton from './TextButton'
 import Popup from './Popup'
-import ListItem from './ListItem'
 import usePopupStore from '../stores/usePopupStore'
 import useSearchStore from '../stores/useSearchStore'
 import { useEffect, useRef } from 'react'
 import { TiMinus, TiPlus } from 'react-icons/ti'
+import useProfiles from '../hooks/useProfiles'
+import ProfileCard from './ProfileCard'
+
+const FaimlySheet = () => {
+  const isSearchBoxOpen = useSearchStore((state) => state.isOpen)
+  const openSearchBox = useSearchStore((state) => state.openSearchBox)
+  const closeSearchBox = useSearchStore((state) => state.closeSearchBox)
+
+  const isPopupOpen = usePopupStore((state) => state.isOpen)
+  const openPopup = usePopupStore((state) => state.openPopup)
+  const closePopup = usePopupStore((state) => state.closePopup)
+
+  const boxRef = useRef<HTMLDivElement | null>(null)
+  const searchRef = useRef<HTMLDivElement | null>(null)
+  const popupRef = useRef<HTMLDivElement | null>(null)
+
+  const { profiles, error, isLoading, setCurrentProfiles } = useProfiles()
+
+  useEffect(() => {
+    const handler = (e: { target: any }) => {
+      if (
+        boxRef.current &&
+        !boxRef.current.contains(e.target) &&
+        searchRef.current &&
+        !searchRef.current.contains(e.target)
+      ) {
+        closeSearchBox()
+      }
+
+      if (popupRef.current && !popupRef.current.contains(e.target)) {
+        closePopup()
+      }
+    }
+    document.addEventListener('mousedown', handler)
+
+    return () => {
+      document.removeEventListener('mousedown', handler)
+    }
+  })
+
+  return (
+    <Container>
+      <SearchBarWrapper ref={searchRef}>
+        <SearchBar
+          onClick={openSearchBox}
+          onChange={(e) => {
+            console.log('Input value:', e.target.value)
+            setCurrentProfiles(e.target.value)
+          }}
+        ></SearchBar>
+      </SearchBarWrapper>
+      {isSearchBoxOpen && (
+        <Box ref={boxRef}>
+          {profiles.map((profile) => (
+            <ProfileCard
+              key={profile.id}
+              profile={profile}
+              icon={TiPlus}
+            ></ProfileCard>
+          ))}
+        </Box>
+      )}
+      <Sheet>
+        {/* {items.map((item, index) => (
+          <ProfileCard nickname={item} key={index} icon={TiMinus}></ProfileCard>
+        ))} */}
+      </Sheet>
+      <TextButtonWrapper>
+        <TextButton
+          text="가족 구성원 모집 완료"
+          isPrimary={true}
+          onClick={openPopup}
+        ></TextButton>
+      </TextButtonWrapper>
+      {isPopupOpen && (
+        <Popup
+          text={'가족 구성원 모집을\n 완료 하시겠습니까?'}
+          onClick={closePopup}
+          ref={popupRef}
+        ></Popup>
+      )}
+    </Container>
+  )
+}
 
 const Container = styled.div`
   display: flex;
@@ -87,77 +170,5 @@ const TextButtonWrapper = styled.div`
   right: 0;
   z-index: 3;
 `
-
-const items = Array.from({ length: 30 }, (_, i) => `Name ${i + 1}`)
-
-const FaimlySheet = () => {
-  const isPopupOpen = usePopupStore((state) => state.isOpen)
-  const openPopup = usePopupStore((state) => state.openPopup)
-  const closePopup = usePopupStore((state) => state.closePopup)
-
-  const isSearchBoxOpen = useSearchStore((state) => state.isOpen)
-  const openSearchBox = useSearchStore((state) => state.openSearchBox)
-  const closeSearchBox = useSearchStore((state) => state.closeSearchBox)
-
-  const boxRef = useRef<HTMLDivElement | null>(null)
-  const searchRef = useRef<HTMLDivElement | null>(null)
-  const popupRef = useRef<HTMLDivElement | null>(null)
-
-  useEffect(() => {
-    const handler = (e: { target: any }) => {
-      if (
-        boxRef.current &&
-        !boxRef.current.contains(e.target) &&
-        searchRef.current &&
-        !searchRef.current.contains(e.target)
-      ) {
-        closeSearchBox()
-      }
-
-      if (popupRef.current && !popupRef.current.contains(e.target)) {
-        closePopup()
-      }
-    }
-    document.addEventListener('mousedown', handler)
-
-    return () => {
-      document.removeEventListener('mousedown', handler)
-    }
-  })
-
-  return (
-    <Container>
-      <SearchBarWrapper ref={searchRef}>
-        <SearchBar onClick={openSearchBox}></SearchBar>
-      </SearchBarWrapper>
-      {isSearchBoxOpen && (
-        <Box ref={boxRef}>
-          {items.map((item, index) => (
-            <ListItem item={item} index={index} icon={TiPlus}></ListItem>
-          ))}
-        </Box>
-      )}
-      <Sheet>
-        {items.map((item, index) => (
-          <ListItem item={item} index={index} icon={TiMinus}></ListItem>
-        ))}
-      </Sheet>
-      <TextButtonWrapper>
-        <TextButton
-          text="가족 구성원 모집 완료"
-          isPrimary={true}
-          onClick={openPopup}
-        ></TextButton>
-      </TextButtonWrapper>
-      {isPopupOpen && (
-        <Popup
-          text={'가족 구성원 모집을\n 완료 하시겠습니까?'}
-          onClick={closePopup}
-          ref={popupRef}
-        ></Popup>
-      )}
-    </Container>
-  )
-}
 
 export default FaimlySheet

--- a/src/components/FamilySheet.tsx
+++ b/src/components/FamilySheet.tsx
@@ -101,9 +101,7 @@ const FaimlySheet = () => {
       {isPopupOpen && (
         <Popup
           text={'가족 구성원 모집을\n 완료 하시겠습니까?'}
-          onClickYes={() => {
-            navigate('/home', { state: { selectedProfiles } })
-          }}
+          onClickYes={() => {}}
           onClickNo={closePopup}
           ref={popupRef}
         ></Popup>

--- a/src/components/FamilySheet.tsx
+++ b/src/components/FamilySheet.tsx
@@ -10,6 +10,7 @@ import useProfiles from '../hooks/useProfiles'
 import ProfileCard from './ProfileCard'
 import useProfileIdState from '../stores/userProfileStore'
 import useProfileState from '../stores/userProfileStore'
+import { useNavigate } from 'react-router-dom'
 
 const FaimlySheet = () => {
   const isSearchBoxOpen = useSearchStore((state) => state.isOpen)
@@ -29,6 +30,8 @@ const FaimlySheet = () => {
   const removeProfile = useProfileState((state) => state.removeProfile)
 
   const { profiles, error, isLoading, setCurrentProfiles } = useProfiles()
+
+  const navigate = useNavigate()
 
   useEffect(() => {
     const handler = (e: { target: any }) => {
@@ -98,7 +101,10 @@ const FaimlySheet = () => {
       {isPopupOpen && (
         <Popup
           text={'가족 구성원 모집을\n 완료 하시겠습니까?'}
-          onClick={closePopup}
+          onClickYes={() => {
+            navigate('/home', { state: { selectedProfiles } })
+          }}
+          onClickNo={closePopup}
           ref={popupRef}
         ></Popup>
       )}

--- a/src/components/FamilySheet.tsx
+++ b/src/components/FamilySheet.tsx
@@ -8,9 +8,8 @@ import { useEffect, useRef } from 'react'
 import { TiMinus, TiPlus } from 'react-icons/ti'
 import useProfiles from '../hooks/useProfiles'
 import ProfileCard from './ProfileCard'
-import useProfileIdState from '../stores/userProfileStore'
 import useProfileState from '../stores/userProfileStore'
-import { useNavigate } from 'react-router-dom'
+import useFamilyCreate from '../hooks/useFamilyCreate'
 
 const FaimlySheet = () => {
   const isSearchBoxOpen = useSearchStore((state) => state.isOpen)
@@ -29,9 +28,9 @@ const FaimlySheet = () => {
   const addProfile = useProfileState((state) => state.addProfile)
   const removeProfile = useProfileState((state) => state.removeProfile)
 
-  const { profiles, error, isLoading, setCurrentProfiles } = useProfiles()
+  const { setCurrentProfiles, profiles, error, isLoading } = useProfiles()
 
-  const navigate = useNavigate()
+  const { familyName, setFamilyName, createFamily } = useFamilyCreate()
 
   useEffect(() => {
     const handler = (e: { target: any }) => {
@@ -100,8 +99,15 @@ const FaimlySheet = () => {
       </TextButtonWrapper>
       {isPopupOpen && (
         <Popup
-          text={'가족 구성원 모집을\n 완료 하시겠습니까?'}
-          onClickYes={() => {}}
+          text={'가족 구성원 이름'}
+          onChange={(familyName) => {
+            setFamilyName(familyName)
+            console.log(familyName)
+          }}
+          onClickYes={() => {
+            const userIds = selectedProfiles.map((profile) => profile.id)
+            createFamily({ userIds: userIds, familyName: familyName })
+          }}
           onClickNo={closePopup}
           ref={popupRef}
         ></Popup>
@@ -127,7 +133,7 @@ const Sheet = styled.div`
   width: 417px;
   height: 493px;
   overflow-y: scroll;
-  border: 2px solid #cdcdcd;
+  border: 2px solid #ffa800;
   border-radius: 16px;
   background: #fff;
   margin-top: 16px;
@@ -150,9 +156,9 @@ const Box = styled.div`
   width: 479px;
   height: 494px;
   overflow-y: scroll;
-  border-left: 2px solid #cdcdcd;
-  border-right: 2px solid #cdcdcd;
-  border-bottom: 2px solid #cdcdcd;
+  border-left: 2px solid #ffa800;
+  border-right: 2px solid #ffa800;
+  border-bottom: 2px solid #ffa800;
   border-radius: 46px;
   background: #fff;
   margin-top: 16px;

--- a/src/components/FamilySheet.tsx
+++ b/src/components/FamilySheet.tsx
@@ -9,8 +9,6 @@ import { TiMinus, TiPlus } from 'react-icons/ti'
 import useProfiles from '../hooks/useProfiles'
 import ProfileCard from './ProfileCard'
 import useProfileState from '../stores/userProfileStore'
-import useFamilyCreate from '../hooks/useFamilyCreate'
-import useCurrentUserStore from '../stores/useCurrentUserStore'
 
 const FaimlySheet = () => {
   const isSearchBoxOpen = useSearchStore((state) => state.isOpen)
@@ -30,8 +28,6 @@ const FaimlySheet = () => {
   const removeProfile = useProfileState((state) => state.removeProfile)
 
   const { setCurrentProfiles, profiles, error, isLoading } = useProfiles()
-
-  const { familyName, setFamilyName, createFamily } = useFamilyCreate()
 
   useEffect(() => {
     const handler = (e: { target: any }) => {
@@ -101,14 +97,6 @@ const FaimlySheet = () => {
       {isPopupOpen && (
         <Popup
           text={'가족 구성원 이름'}
-          onChange={(familyName) => {
-            setFamilyName(familyName)
-            console.log(familyName)
-          }}
-          onClickYes={() => {
-            const userIds = selectedProfiles.map((profile) => profile.id)
-            createFamily({ userIds: userIds, familyName: familyName })
-          }}
           onClickNo={closePopup}
           ref={popupRef}
         ></Popup>

--- a/src/components/FamilySheet.tsx
+++ b/src/components/FamilySheet.tsx
@@ -10,6 +10,7 @@ import useProfiles from '../hooks/useProfiles'
 import ProfileCard from './ProfileCard'
 import useProfileState from '../stores/userProfileStore'
 import useFamilyCreate from '../hooks/useFamilyCreate'
+import useCurrentUserStore from '../stores/useCurrentUserStore'
 
 const FaimlySheet = () => {
   const isSearchBoxOpen = useSearchStore((state) => state.isOpen)

--- a/src/components/LoginForm.tsx
+++ b/src/components/LoginForm.tsx
@@ -8,6 +8,7 @@ import useCurrentUserStore from '../stores/useCurrentUserStore'
 
 const Form = styled.form`
   margin-bottom: 31px;
+  position: relative;
 `
 
 const FormLabel = styled.label`
@@ -46,8 +47,11 @@ const Error = styled.div`
   line-height: 150%;
   letter-spacing: -0.011em;
   color: #ff0000;
+  position: absolute;
   min-height: 24px;
   text-align: center;
+  width: 100%;
+  bottom: -50px;
 `
 const LoginForm = () => {
   const navigate = useNavigate()

--- a/src/components/LoginForm.tsx
+++ b/src/components/LoginForm.tsx
@@ -4,6 +4,7 @@ import { useNavigate } from 'react-router-dom'
 import { useFormik } from 'formik'
 import { AuthRequest } from '../model/AuthRequest'
 import { useLogin } from '../hooks/useLogin'
+import useCurrentUserStore from '../stores/useCurrentUserStore'
 
 const Form = styled.form`
   margin-bottom: 31px;
@@ -52,6 +53,8 @@ const LoginForm = () => {
   const navigate = useNavigate()
 
   const { login, isLoading, error } = useLogin()
+  const { setNickname } = useCurrentUserStore()
+
   const formik = useFormik<AuthRequest>({
     initialValues: {
       nickname: '',
@@ -60,6 +63,7 @@ const LoginForm = () => {
     onSubmit: (authRequest: AuthRequest) => {
       console.log('auth request', authRequest)
       login(authRequest)
+      setNickname(authRequest.nickname)
     },
   })
 

--- a/src/components/Popup.tsx
+++ b/src/components/Popup.tsx
@@ -3,7 +3,8 @@ import { forwardRef } from 'react'
 
 interface Props {
   text: string
-  onClick?: () => void
+  onClickYes: () => void
+  onClickNo: () => void
 }
 
 const PopupContainer = styled.div`
@@ -77,20 +78,22 @@ const ButtonContainer = styled.div`
   margin-bottom: 26px;
 `
 
-const Popup = forwardRef<HTMLDivElement, Props>(({ text, onClick }, ref) => {
-  return (
-    <PopupContainer>
-      <PopupContent ref={ref}>
-        <Title>{text}</Title>
-        <ButtonContainer>
-          <RoundedButton onClick={onClick || (() => {})}>아니요</RoundedButton>
-          <RoundedButton onClick={onClick || (() => {})} isPrimary={true}>
-            네
-          </RoundedButton>
-        </ButtonContainer>
-      </PopupContent>
-    </PopupContainer>
-  )
-})
+const Popup = forwardRef<HTMLDivElement, Props>(
+  ({ text, onClickNo, onClickYes }, ref) => {
+    return (
+      <PopupContainer>
+        <PopupContent ref={ref}>
+          <Title>{text}</Title>
+          <ButtonContainer>
+            <RoundedButton onClick={onClickNo}>아니요</RoundedButton>
+            <RoundedButton onClick={onClickYes} isPrimary={true}>
+              네
+            </RoundedButton>
+          </ButtonContainer>
+        </PopupContent>
+      </PopupContainer>
+    )
+  }
+)
 
 export default Popup

--- a/src/components/Popup.tsx
+++ b/src/components/Popup.tsx
@@ -1,8 +1,9 @@
 import styled from '@emotion/styled'
-import { forwardRef } from 'react'
+import { ChangeEvent, forwardRef } from 'react'
 
 interface Props {
   text: string
+  onChange: (familyName: string) => void
   onClickYes: () => void
   onClickNo: () => void
 }
@@ -45,10 +46,12 @@ const Title = styled.p`
   font-family: Pretendard Variable;
   font-size: 30px;
   font-weight: 600;
-  text-align: center;
+  text-align: left;
   white-space: pre-line;
   line-height: 150%;
   letter-spacing: -1.1%;
+  margin-left: 20px;
+  margin-bottom: 24px;
 `
 
 const RoundedButton = styled.button<{
@@ -72,18 +75,46 @@ const ButtonContainer = styled.div`
   display: flex;
   justify-content: center;
   gap: 30px;
-  margin-top: 60px;
-  margin-left: 21px;
-  margin-right: 21px;
-  margin-bottom: 26px;
+  margin-top: 24px;
+  margin-left: 20px;
+  margin-right: 20px;
+  margin-bottom: 24px;
+`
+
+const Input = styled.input`
+  font-family: Inter;
+  font-style: normal;
+  font-size: 24px;
+  width: 441px;
+  padding: 10px 15px;
+  line-height: 30px;
+  border: none;
+  border-radius: 5px;
+  outline: none;
+  background: #ededed;
+  caret-color: #ffa800;
+
+  &::placeholder {
+    color: #cdcdcd;
+    font-family: Inter;
+    font-style: light;
+    font-size: 20px;
+  }
 `
 
 const Popup = forwardRef<HTMLDivElement, Props>(
-  ({ text, onClickNo, onClickYes }, ref) => {
+  ({ text, onChange, onClickNo, onClickYes }, ref) => {
+    const handleInputChange = (event: ChangeEvent<HTMLInputElement>) => {
+      onChange(event.target.value)
+    }
     return (
       <PopupContainer>
         <PopupContent ref={ref}>
           <Title>{text}</Title>
+          <Input
+            placeholder="가족 구성원의 이름을 지어주세요"
+            onChange={handleInputChange}
+          ></Input>
           <ButtonContainer>
             <RoundedButton onClick={onClickNo}>아니요</RoundedButton>
             <RoundedButton onClick={onClickYes} isPrimary={true}>

--- a/src/components/ProfileCard.tsx
+++ b/src/components/ProfileCard.tsx
@@ -5,6 +5,7 @@ import { Content } from '../model/ProfileResponse'
 interface Props {
   profile: Content
   icon: IconType
+  onClick: () => void
 }
 
 const Container = styled.div`
@@ -46,11 +47,11 @@ const Icon = styled.div`
   cursor: pointer;
 `
 
-const ProfileCard = ({ profile, icon: IconComponent }: Props) => {
+const ProfileCard = ({ profile, icon: IconComponent, onClick }: Props) => {
   return (
     <Container key={profile.id}>
       <Text>{profile.nickname}</Text>
-      <Icon>
+      <Icon onClick={onClick}>
         <IconComponent size={24}></IconComponent>
       </Icon>
     </Container>

--- a/src/components/ProfileCard.tsx
+++ b/src/components/ProfileCard.tsx
@@ -1,9 +1,9 @@
 import styled from '@emotion/styled'
 import { IconType } from 'react-icons'
+import { Content } from '../model/ProfileResponse'
 
 interface Props {
-  nickname: string
-  key: number
+  profile: Content
   icon: IconType
 }
 
@@ -43,12 +43,13 @@ const Icon = styled.div`
   height: 40px;
   border: 2px solid #808080;
   border-radius: 50%;
+  cursor: pointer;
 `
 
-const ProfileCard = ({ nickname, key, icon: IconComponent }: Props) => {
+const ProfileCard = ({ profile, icon: IconComponent }: Props) => {
   return (
-    <Container key={key}>
-      <Text>{nickname}</Text>
+    <Container key={profile.id}>
+      <Text>{profile.nickname}</Text>
       <Icon>
         <IconComponent size={24}></IconComponent>
       </Icon>

--- a/src/components/ProfileCard.tsx
+++ b/src/components/ProfileCard.tsx
@@ -2,8 +2,8 @@ import styled from '@emotion/styled'
 import { IconType } from 'react-icons'
 
 interface Props {
-  item: string
-  index: number
+  nickname: string
+  key: number
   icon: IconType
 }
 
@@ -45,10 +45,10 @@ const Icon = styled.div`
   border-radius: 50%;
 `
 
-const ListItem = ({ item, index, icon: IconComponent }: Props) => {
+const ProfileCard = ({ nickname, key, icon: IconComponent }: Props) => {
   return (
-    <Container key={index}>
-      <Text>{item}</Text>
+    <Container key={key}>
+      <Text>{nickname}</Text>
       <Icon>
         <IconComponent size={24}></IconComponent>
       </Icon>
@@ -56,4 +56,4 @@ const ListItem = ({ item, index, icon: IconComponent }: Props) => {
   )
 }
 
-export default ListItem
+export default ProfileCard

--- a/src/components/RegisterForm.tsx
+++ b/src/components/RegisterForm.tsx
@@ -29,7 +29,8 @@ const InputWrapper = styled.div`
 const InputForm = styled.input<{ placeholder?: string; hasError: boolean }>`
   display: inline-block;
   background-color: #ededed;
-  border: ${({ hasError }) => (hasError ? '1px solid #ff0000' : 'none')};
+  border: ${({ hasError }) =>
+    hasError ? '1px solid #ff0000' : '1px solid #ededed'};
   border-radius: 5px;
   font-family: Inter;
   font-style: normal;
@@ -38,7 +39,7 @@ const InputForm = styled.input<{ placeholder?: string; hasError: boolean }>`
   padding: 10px;
   height: 34px;
   width: 397px;
-  margin-bottom: 35px;
+  margin-bottom: 40px;
 
   &:focus {
     outline: none;
@@ -54,8 +55,8 @@ const Error = styled.div`
   line-height: 150%;
   letter-spacing: -0.011em;
   color: #ff0000;
-  min-height: 24px;
-  margin-top: -30px;
+  position: absolute;
+  margin-top: -36px;
   margin-bottom: 35px;
 `
 
@@ -78,11 +79,10 @@ const RegisterForm = () => {
       confirmPassword: '',
     },
     validationSchema: profileValidationSchema,
-    onSubmit: (profile: Profile, { resetForm }) => {
+    onSubmit: (profile: Profile, { resetForm, setErrors }) => {
       const { confirmPassword, ...profileData } = profile
       console.log(profileData)
-      signup(profileData)
-      resetForm()
+      signup(profileData, setErrors, resetForm)
     },
   })
 

--- a/src/components/SearchBar.tsx
+++ b/src/components/SearchBar.tsx
@@ -13,7 +13,7 @@ const Container = styled.div`
   padding: 18px;
   width: 381px;
   height: 18px;
-  border: 2px solid #cdcdcd;
+  border: 2px solid #ffa800;
   border-radius: 50px;
   background: #fff;
 `
@@ -27,6 +27,7 @@ const Input = styled.input`
   border: none;
   outline: none;
   background: none;
+  caret-color: #ffa800;
 
   &::placeholder {
     color: #cdcdcd;

--- a/src/components/SearchBar.tsx
+++ b/src/components/SearchBar.tsx
@@ -3,6 +3,7 @@ import { FiSearch } from 'react-icons/fi'
 
 interface Props {
   onClick: () => void
+  onChange: (e: any) => void
 }
 
 const Container = styled.div`
@@ -40,13 +41,14 @@ const Icon = styled(FiSearch)`
   width: 30px;
   height: 30px;
 `
-const SearchBar = ({ onClick }: Props) => {
+const SearchBar = ({ onClick, onChange }: Props) => {
   return (
     <Container>
       <Input
         type="text"
         placeholder="가족 구성원의 닉네임을 검색해주세요."
         onClick={onClick}
+        onChange={onChange}
       ></Input>
       <Icon></Icon>
     </Container>

--- a/src/config/api-client.ts
+++ b/src/config/api-client.ts
@@ -1,5 +1,5 @@
 import axios from 'axios'
-import { AuthResponse } from '../model/AuthResponse'
+import useCurrentUserStore from '../stores/useCurrentUserStore'
 
 const apiClient = axios.create({
   baseURL: 'http://211.188.49.236:5252/api/v1',
@@ -8,9 +8,8 @@ const apiClient = axios.create({
 apiClient.interceptors.request.use(
   (config) => {
     if (!config.url?.includes('/login') && !config.url?.includes('/signup')) {
-      const authObject = localStorage.getItem('user')
-      if (authObject) {
-        const { accessToken } = JSON.parse(authObject) as AuthResponse
+      const { accessToken } = useCurrentUserStore.getState()
+      if (accessToken) {
         config.headers.Authorization = `Bearer ${accessToken}`
       }
     }

--- a/src/hooks/useFamilyCreate.ts
+++ b/src/hooks/useFamilyCreate.ts
@@ -15,8 +15,9 @@ const useFamilyCreate = () => {
     createNewFamily(familyCreateRequest)
       .then((response) => {
         if (response && response.status === 201) {
+          const familyId = response.data.familyId
           navigate('/home')
-          localStorage.setItem('familyId', JSON.stringify(response.data))
+          localStorage.setItem('familyId', familyId.toString())
         }
       })
       .catch((error) => setError(error.message))

--- a/src/hooks/useFamilyCreate.ts
+++ b/src/hooks/useFamilyCreate.ts
@@ -4,7 +4,6 @@ import { FamilyCreateRequest } from '../model/FamilyCreateRequest'
 import { useNavigate } from 'react-router-dom'
 
 const useFamilyCreate = () => {
-  const [familyName, setFamilyName] = useState<string>('')
   const [error, setError] = useState<string>('')
   const [isLoading, setLoader] = useState<boolean>(false)
 
@@ -23,7 +22,7 @@ const useFamilyCreate = () => {
       .catch((error) => setError(error.message))
       .finally(() => setLoader(false))
   }
-  return { familyName, setFamilyName, createFamily, error, isLoading }
+  return { createFamily, error, isLoading }
 }
 
 export default useFamilyCreate

--- a/src/hooks/useFamilyCreate.ts
+++ b/src/hooks/useFamilyCreate.ts
@@ -1,0 +1,27 @@
+import { useState } from 'react'
+import { createNewFamily } from '../services/family-service'
+import { FamilyCreateRequest } from '../model/FamilyCreateRequest'
+import { useNavigate } from 'react-router-dom'
+
+const useFamilyCreate = () => {
+  const [error, setError] = useState<string>('')
+  const [isLoading, setLoader] = useState<boolean>(false)
+
+  const navigate = useNavigate()
+
+  const createFamily = (familyCreateRequest: FamilyCreateRequest) => {
+    setLoader(true)
+    createNewFamily(familyCreateRequest)
+      .then((response) => {
+        if (response && response.status === 201) {
+          navigate('/home')
+          localStorage.setItem('familyId', JSON.stringify(response.data))
+        }
+      })
+      .catch((error) => setError(error.message))
+      .finally(() => setLoader(false))
+  }
+  return { error, isLoading, createFamily }
+}
+
+export default useFamilyCreate

--- a/src/hooks/useFamilyCreate.ts
+++ b/src/hooks/useFamilyCreate.ts
@@ -4,6 +4,7 @@ import { FamilyCreateRequest } from '../model/FamilyCreateRequest'
 import { useNavigate } from 'react-router-dom'
 
 const useFamilyCreate = () => {
+  const [familyName, setFamilyName] = useState<string>('')
   const [error, setError] = useState<string>('')
   const [isLoading, setLoader] = useState<boolean>(false)
 
@@ -21,7 +22,7 @@ const useFamilyCreate = () => {
       .catch((error) => setError(error.message))
       .finally(() => setLoader(false))
   }
-  return { error, isLoading, createFamily }
+  return { familyName, setFamilyName, createFamily, error, isLoading }
 }
 
 export default useFamilyCreate

--- a/src/hooks/useLogin.ts
+++ b/src/hooks/useLogin.ts
@@ -13,7 +13,7 @@ export const useLogin = () => {
     setLoader(true)
     authenticate(authRequest)
       .then((response) => {
-        localStorage.setItem('user', JSON.stringify(response.data.accessToken))
+        localStorage.setItem('user', JSON.stringify(response.data))
         updateAuth(true)
         navigate('/search')
       })

--- a/src/hooks/useLogin.ts
+++ b/src/hooks/useLogin.ts
@@ -3,17 +3,22 @@ import { useState } from 'react'
 import { useNavigate } from 'react-router-dom'
 import { AuthRequest } from '../model/AuthRequest'
 import { useAuthContext } from './useAuthContext'
+import useCurrentUserStore from '../stores/useCurrentUserStore'
 
 export const useLogin = () => {
   const [error, setError] = useState<string>('')
   const [isLoading, setLoader] = useState<boolean>(false)
+
   const navigate = useNavigate()
   const { updateAuth } = useAuthContext()
+
+  const { setAccessToken } = useCurrentUserStore()
+
   const login = (authRequest: AuthRequest) => {
     setLoader(true)
     authenticate(authRequest)
       .then((response) => {
-        localStorage.setItem('user', JSON.stringify(response.data))
+        setAccessToken(response.data.accessToken)
         updateAuth(true)
         navigate('/search')
       })

--- a/src/hooks/useProfiles.ts
+++ b/src/hooks/useProfiles.ts
@@ -1,0 +1,21 @@
+import { ProfileResponse } from '../model/ProfileResponse'
+import { getProfiles } from '../services/family-service'
+import React, { useEffect, useState } from 'react'
+
+const useProfiles = () => {
+  const [profiles, setProfiles] = useState<ProfileResponse[]>([])
+  const [error, setErrors] = useState<string>('')
+  const [isLoading, setLoader] = useState<boolean>(false)
+  useEffect(() => {
+    setLoader(true)
+    getProfiles()
+      .then((response) => {
+        setProfiles(response.data)
+      })
+      .catch((error) => setErrors(error.message))
+      .finally(() => setLoader(false))
+  }, [])
+  return { profiles, error, isLoading }
+}
+
+export default useProfiles

--- a/src/hooks/useProfiles.ts
+++ b/src/hooks/useProfiles.ts
@@ -1,21 +1,25 @@
-import { ProfileResponse } from '../model/ProfileResponse'
+import { Content } from '../model/ProfileResponse'
 import { getProfiles } from '../services/family-service'
-import React, { useEffect, useState } from 'react'
+import { useEffect, useState } from 'react'
 
 const useProfiles = () => {
-  const [profiles, setProfiles] = useState<ProfileResponse[]>([])
+  const [currentUser, setCurrentProfiles] = useState<string>('')
+  const [profiles, setProfiles] = useState<Content[]>([])
   const [error, setErrors] = useState<string>('')
   const [isLoading, setLoader] = useState<boolean>(false)
   useEffect(() => {
+    if (currentUser.trim() === '') return
+
     setLoader(true)
-    getProfiles()
+    getProfiles(currentUser)
       .then((response) => {
-        setProfiles(response.data)
+        setProfiles(response.data.contents)
+        console.log('Response Data:', response.data.contents)
       })
       .catch((error) => setErrors(error.message))
       .finally(() => setLoader(false))
-  }, [])
-  return { profiles, error, isLoading }
+  }, [currentUser])
+  return { profiles, error, isLoading, setCurrentProfiles }
 }
 
 export default useProfiles

--- a/src/hooks/useProfiles.ts
+++ b/src/hooks/useProfiles.ts
@@ -1,19 +1,29 @@
 import { Content } from '../model/ProfileResponse'
-import { getProfiles } from '../services/family-service'
+import { fetchProfiles } from '../services/family-service'
 import { useEffect, useState } from 'react'
+import useCurrentUserStore from '../stores/useCurrentUserStore'
 
 const useProfiles = () => {
   const [currentUser, setCurrentProfiles] = useState<string>('')
   const [profiles, setProfiles] = useState<Content[]>([])
   const [error, setErrors] = useState<string>('')
   const [isLoading, setLoader] = useState<boolean>(false)
-  useEffect(() => {
-    if (currentUser.trim() === '') return
 
+  const { nickname } = useCurrentUserStore()
+
+  useEffect(() => {
+    if (currentUser.trim() === '') {
+      console.log('Current user is empty, skipping fetch.')
+      return
+    }
     setLoader(true)
-    getProfiles(currentUser)
+    fetchProfiles(currentUser)
       .then((response) => {
-        setProfiles(response.data.contents)
+        const filteredProfiles = response.data.contents.filter(
+          (profile: Content) => profile.nickname !== nickname
+        )
+        console.log('Filtered profiles:', filteredProfiles)
+        setProfiles(filteredProfiles)
         console.log('Response Data:', response.data.contents)
       })
       .catch((error) => setErrors(error.message))

--- a/src/hooks/useProfiles.ts
+++ b/src/hooks/useProfiles.ts
@@ -19,7 +19,7 @@ const useProfiles = () => {
       .catch((error) => setErrors(error.message))
       .finally(() => setLoader(false))
   }, [currentUser])
-  return { profiles, error, isLoading, setCurrentProfiles }
+  return { setCurrentProfiles, profiles, error, isLoading }
 }
 
 export default useProfiles

--- a/src/hooks/useRegister.ts
+++ b/src/hooks/useRegister.ts
@@ -7,7 +7,9 @@ export const useRegister = () => {
   const [error, setError] = useState<string>('')
   const [isLoading, setLoader] = useState<boolean>(false)
   const [toast, setToast] = useState<string>('')
+
   const navigate = useNavigate()
+
   const signup = (profile: AuthRequest) => {
     setLoader(true)
     createProfile(profile)

--- a/src/hooks/useRegister.ts
+++ b/src/hooks/useRegister.ts
@@ -10,16 +10,30 @@ export const useRegister = () => {
 
   const navigate = useNavigate()
 
-  const signup = (profile: AuthRequest) => {
+  const signup = (
+    profile: AuthRequest,
+    setErrors: (errors: any) => void,
+    resetForm: () => void
+  ) => {
     setLoader(true)
     createProfile(profile)
       .then((response) => {
         if (response && response.status === 201) {
           setToast('Profile is successfully created')
+          resetForm()
           navigate('/login')
         }
       })
-      .catch((error) => setError(error.message))
+      .catch((error) => {
+        if (
+          error.response &&
+          error.response.data.code === 'USER_NICKNAME_DUPLICATED'
+        ) {
+          setErrors({ nickname: '중복된 닉네임입니다.' })
+        } else {
+          setError(error.message)
+        }
+      })
       .finally(() => setLoader(false))
   }
   return { error, isLoading, signup, toast }

--- a/src/main.tsx
+++ b/src/main.tsx
@@ -9,13 +9,21 @@ import Register from './pages/Register.tsx'
 import Search from './pages/search.tsx'
 import Select from './pages/Select.tsx'
 import { AuthContextProvider } from './context/AuthContext.tsx'
+import { useAuthContext } from './hooks/useAuthContext.ts'
+
+const ProtectedRoute = ({ element }: { element: JSX.Element }) => {
+  const { isAuthenticated } = useAuthContext()
+
+  return isAuthenticated ? element : <Login />
+}
 
 const router = createBrowserRouter([
-  { path: '/home', element: <Home /> },
+  { path: '/', element: <ProtectedRoute element={<Select />} /> },
+  { path: '/home', element: <ProtectedRoute element={<Home />} /> },
   { path: '/login', element: <Login /> },
-  { path: '/register', element: <Register /> },
-  { path: '/search', element: <Search /> },
-  { path: '/select', element: <Select /> },
+  { path: '/register', element: <ProtectedRoute element={<Register />} /> },
+  { path: '/search', element: <ProtectedRoute element={<Search />} /> },
+  { path: '/select', element: <ProtectedRoute element={<Select />} /> },
 ])
 
 createRoot(document.getElementById('root')!).render(

--- a/src/main.tsx
+++ b/src/main.tsx
@@ -21,7 +21,7 @@ const router = createBrowserRouter([
   { path: '/', element: <ProtectedRoute element={<Select />} /> },
   { path: '/home', element: <ProtectedRoute element={<Home />} /> },
   { path: '/login', element: <Login /> },
-  { path: '/register', element: <ProtectedRoute element={<Register />} /> },
+  { path: '/register', element: <Register /> },
   { path: '/search', element: <ProtectedRoute element={<Search />} /> },
   { path: '/select', element: <ProtectedRoute element={<Select />} /> },
 ])

--- a/src/model/FamilyCreateRequest.ts
+++ b/src/model/FamilyCreateRequest.ts
@@ -1,0 +1,4 @@
+export interface FamilyCreateRequest {
+  userIds: number[]
+  familyName: string
+}

--- a/src/model/FamilyCreateResponse.ts
+++ b/src/model/FamilyCreateResponse.ts
@@ -1,0 +1,3 @@
+export interface FamilyCreateResponse {
+  familyId: number
+}

--- a/src/model/ProfileResponse.ts
+++ b/src/model/ProfileResponse.ts
@@ -1,3 +1,4 @@
 export interface ProfileResponse {
   id: number
+  nickname: string
 }

--- a/src/model/ProfileResponse.ts
+++ b/src/model/ProfileResponse.ts
@@ -1,4 +1,8 @@
-export interface ProfileResponse {
+export interface Content {
   id: number
   nickname: string
+}
+
+export interface ProfileResponse {
+  contents: Content[]
 }

--- a/src/services/family-service.ts
+++ b/src/services/family-service.ts
@@ -3,7 +3,7 @@ import apiClient from '../config/api-client'
 import { FamilyCreateRequest } from '../model/FamilyCreateRequest'
 import { FamilyCreateResponse } from '../model/FamilyCreateResponse'
 
-export const getProfiles = (nickname: string) => {
+export const fetchProfiles = (nickname: string) => {
   return apiClient.get<ProfileResponse>('/users', {
     params: { nickname: nickname },
   })

--- a/src/services/family-service.ts
+++ b/src/services/family-service.ts
@@ -1,0 +1,6 @@
+import { ProfileResponse } from './../model/ProfileResponse'
+import apiClient from '../config/api-client'
+
+export const getProfiles = () => {
+  return apiClient.get<ProfileResponse[]>('/users')
+}

--- a/src/services/family-service.ts
+++ b/src/services/family-service.ts
@@ -1,6 +1,7 @@
 import { ProfileResponse } from './../model/ProfileResponse'
 import apiClient from '../config/api-client'
 import { FamilyCreateRequest } from '../model/FamilyCreateRequest'
+import { FamilyCreateResponse } from '../model/FamilyCreateResponse'
 
 export const getProfiles = (nickname: string) => {
   return apiClient.get<ProfileResponse>('/users', {
@@ -9,5 +10,5 @@ export const getProfiles = (nickname: string) => {
 }
 
 export const createNewFamily = (family: FamilyCreateRequest) => {
-  return apiClient.post<number>('/family/members', family)
+  return apiClient.post<FamilyCreateResponse>('/family/members', family)
 }

--- a/src/services/family-service.ts
+++ b/src/services/family-service.ts
@@ -1,8 +1,13 @@
 import { ProfileResponse } from './../model/ProfileResponse'
 import apiClient from '../config/api-client'
+import { FamilyCreateRequest } from '../model/FamilyCreateRequest'
 
 export const getProfiles = (nickname: string) => {
   return apiClient.get<ProfileResponse>('/users', {
     params: { nickname: nickname },
   })
+}
+
+export const createNewFamily = (family: FamilyCreateRequest) => {
+  return apiClient.post<number>('/family/members', family)
 }

--- a/src/services/family-service.ts
+++ b/src/services/family-service.ts
@@ -1,6 +1,8 @@
 import { ProfileResponse } from './../model/ProfileResponse'
 import apiClient from '../config/api-client'
 
-export const getProfiles = () => {
-  return apiClient.get<ProfileResponse[]>('/users')
+export const getProfiles = (nickname: string) => {
+  return apiClient.get<ProfileResponse>('/users', {
+    params: { nickname: nickname },
+  })
 }

--- a/src/stores/useCurrentUserStore.ts
+++ b/src/stores/useCurrentUserStore.ts
@@ -1,0 +1,17 @@
+import { create } from 'zustand'
+
+interface ProfileState {
+  nickname: string
+  accessToken: string
+  setNickname: (nickname: string) => void
+  setAccessToken: (accessToken: string) => void
+}
+
+const useProfileState = create<ProfileState>((set) => ({
+  nickname: '',
+  accessToken: '',
+  setNickname: (newNickname) => set({ nickname: newNickname }),
+  setAccessToken: (newAccessToken) => set({ accessToken: newAccessToken }),
+}))
+
+export default useProfileState

--- a/src/stores/userProfileStore.ts
+++ b/src/stores/userProfileStore.ts
@@ -9,8 +9,15 @@ interface ProfileState {
 
 const useProfileState = create<ProfileState>((set) => ({
   contents: [],
-  addProfile: (profile) =>
-    set((state) => ({ contents: [...state.contents, profile] })),
+  addProfile: (profile) => {
+    set((state) => {
+      const exists = state.contents.some((p) => p.id === profile.id)
+      if (!exists) {
+        return { contents: [...state.contents, profile] }
+      }
+      return state
+    })
+  },
   removeProfile: (id) =>
     set((state) => ({ contents: state.contents.filter((p) => p.id !== id) })),
 }))

--- a/src/stores/userProfileStore.ts
+++ b/src/stores/userProfileStore.ts
@@ -1,0 +1,18 @@
+import { create } from 'zustand'
+import { Content } from '../model/ProfileResponse'
+
+interface ProfileState {
+  contents: Content[]
+  addProfile: (content: Content) => void
+  removeProfile: (id: number) => void
+}
+
+const useProfileState = create<ProfileState>((set) => ({
+  contents: [],
+  addProfile: (profile) =>
+    set((state) => ({ contents: [...state.contents, profile] })),
+  removeProfile: (id) =>
+    set((state) => ({ contents: state.contents.filter((p) => p.id !== id) })),
+}))
+
+export default useProfileState

--- a/src/validation/familyNameValidationSchema.ts
+++ b/src/validation/familyNameValidationSchema.ts
@@ -1,0 +1,7 @@
+import * as yup from 'yup'
+
+const profileValidationSchema = yup.object().shape({
+  familyName: yup.string().required('가족 구성원의 이름을 지어주세요'),
+})
+
+export default profileValidationSchema


### PR DESCRIPTION
## #️⃣연관된 이슈

> #6 

## 📝작업 내용

- 컴포넌트 이름 변경 ListItem -> ProfileCard 
- 유저 검색 기능 추가 (real-time search)
- 가족 생성 validation 추가 (이미 선택한 유저 중복 추가 방지)
- authenticated 상태에 따른 navigate 추가(redirect to login screen)


![splasfshdd-1](https://github.com/user-attachments/assets/c6892cf5-b8bd-4cb3-be48-6e62c8b1fe9d)

## 💬리뷰 요구사항(선택)

> localStorage에 저장 되는 값 확인해주세요!
유저가 자기 자신을 검색하지 못하도록 해야하는데 방법이 잘 생각이 안 떠올라 우선 보류했습니다!
그리고 위젯의 수치에 대해서 어제 세미나에서 성원님이 말씀해주셨는데
꼭 4배수로 코드를 작성해야한다고 합니다! 디자이너가 피그마로 보여줄 때 픽셀을 신경쓰지 못하는 경우가 있다고 하네요
모든 컴포넌트를 고치기는 힘들 것 같아서 우선 새로 수정한 부분들만 4배수로 만들었습니다!
