### PR TITLE
[Fix] Update Home Screen api

### DIFF
--- a/src/components/AnswerBox.tsx
+++ b/src/components/AnswerBox.tsx
@@ -21,7 +21,15 @@ const Box = styled.div<{
   flex-direction: column;
   align-items: center;
   gap: 20px;
-  overflow-y: auto;
+  overflow-x: none;
+  overflow-y: scroll;
+  scrollbar-width: thin;
+  scrollbar-color: rgba(0, 0, 0, 0.2) transparent;
+
+  &::-webkit-scrollbar {
+    width: 0px;
+  }
+
   transition: opacity 0.5s, transform 0.5s;
 
   display: ${(props) => (props.isDisplayed ? 'flex' : 'none')};

--- a/src/components/AnswerModal.tsx
+++ b/src/components/AnswerModal.tsx
@@ -12,7 +12,7 @@ const AnswerModalBackground = styled.div<{ isOpen: boolean }>`
   left: 0px;
   top: 0px;
 
-  background-color: rgba(0, 0, 0, 0.61);
+  background-color: rgba(0, 0, 0, 0.061);
   z-index: 2;
 `
 

--- a/src/components/GetQuestionBtn.tsx
+++ b/src/components/GetQuestionBtn.tsx
@@ -1,9 +1,12 @@
+import { useNavigate } from 'react-router-dom'
 import styled from '@emotion/styled'
 import useQuestionStore from '../stores/UseQuestionStore'
 import UseGetQuestionBtnStore from '../stores/UseGetQuestionBtnStore'
+import { UseCursorStore } from '../stores/\bUseCursorStore'
+
 import { loadFamilyId } from '../utils/UserToken'
 
-const GetQuestion = styled.button<{ activate: boolean }>`
+const GetQuestion = styled.button<{ activate: boolean; isLoading: boolean }>`
   position: absolute;
   width: 388px;
   height: 116px;
@@ -14,7 +17,10 @@ const GetQuestion = styled.button<{ activate: boolean }>`
   background: ${(props) => (props.activate ? '#ffa800' : '#ffffff')};
   border-radius: 20px;
   border: 5px solid #ffa800;
-  cursor: ${(props) => (props.activate ? 'pointer' : 'not-allowed')};
+  cursor: ${(props) => {
+    if (props.isLoading) return 'wait'
+    return props.activate ? 'pointer' : 'not-allowed'
+  }};
 `
 
 const GetSvg = styled.svg`
@@ -51,6 +57,7 @@ const GetQuestionTxt = styled.p<{ activate: boolean }>`
 `
 
 function GetQuestionBtn() {
+  const navigate = useNavigate()
   const { fetchNewQuestions, isFetching, setIsFetching } = useQuestionStore(
     (state) => ({
       fetchNewQuestions: state.fetchNewQuestions,
@@ -58,10 +65,10 @@ function GetQuestionBtn() {
       setIsFetching: state.setIsFetching,
     })
   )
-
   const { activate } = UseGetQuestionBtnStore((state) => ({
     activate: state.activate,
   }))
+  const { isLoading, setIsLoading } = UseCursorStore()
 
   const getQuestion = async () => {
     const familyId = loadFamilyId()
@@ -70,18 +77,24 @@ function GetQuestionBtn() {
     if (isFetching) return console.log('질문을 받아오는 중입니다.')
 
     try {
+      setIsLoading(true)
       const id = Number(familyId)
       await fetchNewQuestions(id)
-      location.reload()
+      navigate('/home')
     } catch (error) {
       console.error('새 질문을 받아오는 데 실패했습니다.', error)
     } finally {
       setIsFetching(false)
+      setIsLoading(false)
     }
   }
 
   return (
-    <GetQuestion onClick={getQuestion} activate={activate}>
+    <GetQuestion
+      onClick={getQuestion}
+      activate={activate}
+      isLoading={isLoading}
+    >
       <GetSvg viewBox="0 0 42 42" xmlns="http://www.w3.org/2000/svg">
         <path
           d="M21 4V38M4 21H38"

--- a/src/components/GetQuestionBtn.tsx
+++ b/src/components/GetQuestionBtn.tsx
@@ -36,7 +36,7 @@ const GetSvg = styled.svg`
 
 const GetQuestionTxt = styled.p<{ activate: boolean }>`
   position: absolute;
-  width: 219px;
+  width: 20vw;
   height: 51px;
   left: 27.32%;
   right: 16.24%;

--- a/src/components/LogoutBtn.tsx
+++ b/src/components/LogoutBtn.tsx
@@ -26,7 +26,6 @@ function LogoutBtn() {
   const navigate = useNavigate()
 
   const logout = () => {
-    localStorage.removeItem('user')
     localStorage.removeItem('familyId')
     navigate('/login')
     console.log('logout')

--- a/src/hooks/useLogin.ts
+++ b/src/hooks/useLogin.ts
@@ -20,7 +20,7 @@ export const useLogin = () => {
       .then((response) => {
         setAccessToken(response.data.accessToken)
         updateAuth(true)
-        navigate('/search')
+        navigate('/select')
       })
       .catch((error) => {
         if (

--- a/src/pages/home.tsx
+++ b/src/pages/home.tsx
@@ -31,6 +31,12 @@ const QuestionListContainer = styled.div`
   flex-direction: column;
   gap: 20px;
   overflow-y: scroll;
+  scrollbar-width: thin;
+  scrollbar-color: rgba(0, 0, 0, 0.2) transparent;
+
+  &::-webkit-scrollbar {
+    width: 0px;
+  }
 `
 
 const QuestionAnswerBox = styled.div`

--- a/src/pages/home.tsx
+++ b/src/pages/home.tsx
@@ -30,12 +30,28 @@ const QuestionListContainer = styled.div`
   display: flex;
   flex-direction: column;
   gap: 20px;
+  overflow-x: hidden;
   overflow-y: scroll;
   scrollbar-width: thin;
-  scrollbar-color: rgba(0, 0, 0, 0.2) transparent;
+  scrollbar-color: rgba(155, 155, 155, 0.5) transparent;
 
   &::-webkit-scrollbar {
-    width: 0px;
+    width: 12px;
+  }
+
+  ::-webkit-scrollbar-track {
+    background-color: transparent;
+  }
+
+  ::-webkit-scrollbar-thumb {
+    background: rgba(155, 155, 155, 0.5);
+    border-radius: 10px;
+    border: 2px solid transparent;
+    background-clip: padding-box;
+  }
+
+  ::-webkit-scrollbar-thumb:hover {
+    background-color: rgba(155, 155, 155, 0.8);
   }
 `
 

--- a/src/services/FamilyAnswerApi.ts
+++ b/src/services/FamilyAnswerApi.ts
@@ -1,17 +1,9 @@
 import axios from 'axios'
-import { loadAuthToken } from '../utils/UserToken'
-
-const token = loadAuthToken()
+import apiClient from '../config/api-client'
 
 export const FetchFamilyAnswers = async (familyId: number) => {
   try {
-    const response = await axios.get(`/family/answer/${familyId}`, {
-      headers: {
-        Authorization: `Bearer ${token}`,
-        accept: 'application/json',
-      },
-    })
-    console.log(response.data)
+    const response = await apiClient.get(`/family/answer/${familyId}`)
     return response.data
   } catch (error) {
     console.error('Error fetching data:', error)
@@ -21,19 +13,9 @@ export const FetchFamilyAnswers = async (familyId: number) => {
 
 export const PostFamilyAnswer = async (familyId: number, content: string) => {
   try {
-    const response = await axios.post(
-      `/family/answer/${familyId}`,
-      { content },
-      {
-        headers: {
-          Authorization: `Bearer ${token}`,
-          accept: 'application/json',
-          'Content-Type': 'application/json',
-        },
-      }
-    )
-    console.log(response.data)
-    return response.data
+    await apiClient.post(`/family/answer/${familyId}`, {
+      content,
+    })
   } catch (error) {
     if (axios.isAxiosError(error) && error.response) {
       alert(error.response.data.message || 'An unexpected error occurred')

--- a/src/services/GetFamilyAnswerApi.ts
+++ b/src/services/GetFamilyAnswerApi.ts
@@ -1,16 +1,8 @@
-import axios from 'axios'
-import { loadAuthToken } from '../utils/UserToken'
-
-const token = loadAuthToken()
+import apiClient from '../config/api-client'
 
 export const FetchFamilyAnswers = async (familyQuestionId: number) => {
   try {
-    const response = await axios.get(`/family/answer/${familyQuestionId}`, {
-      headers: {
-        Authorization: `Bearer ${token}`,
-        accept: 'application/json',
-      },
-    })
+    const response = await apiClient.get(`/family/answer/${familyQuestionId}`)
     console.log(response.data)
     return response.data
   } catch (error) {

--- a/src/services/GetFamilyAnswerApi.ts
+++ b/src/services/GetFamilyAnswerApi.ts
@@ -3,7 +3,6 @@ import apiClient from '../config/api-client'
 export const FetchFamilyAnswers = async (familyQuestionId: number) => {
   try {
     const response = await apiClient.get(`/family/answer/${familyQuestionId}`)
-    console.log(response.data)
     return response.data
   } catch (error) {
     console.error('Error fetching data:', error)

--- a/src/services/GetFamilyApi.ts
+++ b/src/services/GetFamilyApi.ts
@@ -1,16 +1,8 @@
-import axios from 'axios'
-import { loadAuthToken } from '../utils/UserToken'
-
-const token = loadAuthToken()
+import apiClient from '../config/api-client'
 
 export const FetchFamilyData = async (familyId: number) => {
   try {
-    const response = await axios.get(`/family/${familyId}`, {
-      headers: {
-        Authorization: `Bearer ${token}`,
-        accept: 'application/json',
-      },
-    })
+    const response = await apiClient.get(`/family/${familyId}`)
     console.log(response.data)
     return response.data
   } catch (error) {

--- a/src/services/GetFamilyListApi.ts
+++ b/src/services/GetFamilyListApi.ts
@@ -1,16 +1,8 @@
-import axios from 'axios'
-import { loadAuthToken } from '../utils/UserToken'
-
-const token = loadAuthToken()
+import apiClient from '../config/api-client'
 
 export const FetchFamilyList = async () => {
   try {
-    const response = await axios.get('/family/list', {
-      headers: {
-        Authorization: `Bearer ${token}`,
-        accept: 'application/json',
-      },
-    })
+    const response = await apiClient.get(`/family/list`)
     console.log(response.data)
     return response.data
   } catch (error) {

--- a/src/services/GetFamilyListApi.ts
+++ b/src/services/GetFamilyListApi.ts
@@ -3,7 +3,6 @@ import apiClient from '../config/api-client'
 export const FetchFamilyList = async () => {
   try {
     const response = await apiClient.get(`/family/list`)
-    console.log(response.data)
     return response.data
   } catch (error) {
     console.error('Error fetching family list:', error)

--- a/src/services/GetFamilyQuestionApi.ts
+++ b/src/services/GetFamilyQuestionApi.ts
@@ -1,7 +1,5 @@
 import axios from 'axios'
-import { loadAuthToken } from '../utils/UserToken'
-
-const token = loadAuthToken()
+import apiClient from '../config/api-client'
 
 export const FetchFamilyQuestions = async (
   familyId: number,
@@ -9,14 +7,8 @@ export const FetchFamilyQuestions = async (
   size: number
 ) => {
   try {
-    const response = await axios.get(
-      `/family/question/${familyId}?page=${page}&size=${size}`,
-      {
-        headers: {
-          Authorization: `Bearer ${token}`,
-          accept: 'application/json',
-        },
-      }
+    const response = await apiClient.get(
+      `/family/question/${familyId}?page=${page}&size=${size}`
     )
     return response.data
   } catch (error) {
@@ -35,17 +27,7 @@ export const FetchFamilyQuestions = async (
 
 export const FetchFamilyNewQuestions = async (familyId: number) => {
   try {
-    const response = await axios.post(
-      `/family/question/${familyId}`,
-      {},
-      {
-        headers: {
-          Authorization: `Bearer ${token}`,
-          accept: 'application/json',
-          'Content-Type': 'application/json',
-        },
-      }
-    )
+    const response = await apiClient.post(`/family/question/${familyId}`, {})
     console.log(response.data)
     return response.data
   } catch (error) {

--- a/src/stores/UseCursorStore.ts
+++ b/src/stores/UseCursorStore.ts
@@ -1,0 +1,11 @@
+import { create } from 'zustand'
+
+interface CursorState {
+  isLoading: boolean
+  setIsLoading: (loading: boolean) => void
+}
+
+export const UseCursorStore = create<CursorState>((set) => ({
+  isLoading: false,
+  setIsLoading: (loading: boolean) => set({ isLoading: loading }),
+}))

--- a/src/utils/UserToken.ts
+++ b/src/utils/UserToken.ts
@@ -1,7 +1,3 @@
-export const loadAuthToken = (): string | null => {
-  return localStorage.getItem('user')
-}
-
 export const loadFamilyId = (): string | null => {
   return localStorage.getItem('familyId')
 }


### PR DESCRIPTION
## #️⃣연관된 PR

> #19 

## 📝작업 내용

> `home` 스크린에 쓰이는 모든 api 서비스 코드에서 `localStorage`가 아닌 `api-Client`를 통해 요청을 처리하도록 수정하였습니다.
> 로그인 후 `search` 스크린으로 이동합니다.
> 버튼 클릭 후 렌더링이 되기까지 시간이 걸리는 경우 `cursor`의 속성을 `wait`로 주었습니다.
> 스크롤바를 커스텀하여 사용하였습니다.

### 스크린샷

> ![무제](https://github.com/user-attachments/assets/9a4e1fdc-5d36-4305-ae47-4f12c5d1ef65)


## 💬리뷰 요구사항

> 스크린샷에는 깨졌지만 `cursor: 'wait';` 속성은 정상적으로 적용됩니다.
